### PR TITLE
Double-shot fixed

### DIFF
--- a/addons/rolltracker/rolltracker.lua
+++ b/addons/rolltracker/rolltracker.lua
@@ -177,12 +177,13 @@ end
 	
 
 function event_outgoing_text(original, modified)
-	if original:find('/jobability \"Double') and luckyroll == 1 and override == 0 and id == get_player()['id'] then
+	if original:find('/jobability \"Double.*Up') and luckyroll == 1 and override == 0 and id == get_player()['id'] then
 		modified=''
 		add_to_chat(159,'You either have a lucky Roll or have rolled an 11. Reuse Double-Up to continue to double-up.')
 		luckyroll=0
 		return modified
 	end
 end
+
 
 


### PR DESCRIPTION
Don't know why I can't just type Double-up, but it never works with
that, so used .*
