### PR TITLE
Add color setting for NPC magic casting (enemies, automatons)

### DIFF
--- a/addons/battlemod/data/colors.xml
+++ b/addons/battlemod/data/colors.xml
@@ -34,6 +34,7 @@
 		<otherdmg>0</otherdmg>
 		
 		<spellcol>0</spellcol>
+		<mobspellcol>0</mobspellcol>
 		<abilcol>0</abilcol>
 		<wscol>0</wscol>
 		<mobwscol>0</mobwscol>

--- a/addons/battlemod/event_action.lua
+++ b/addons/battlemod/event_action.lua
@@ -219,7 +219,11 @@ function event_action(act)
 					if T{252,265,268,269,271,272,274,275,650}:contains(msg_ID) then
 						spell = 'Magic Burst '..spell
 					end
-					spell = color_it(spell,color_arr['spellcol'])
+					if actor_table['is_npc'] then
+						spell = color_it(spell or '',color_arr['mobspellcol'])
+					else
+						spell = color_it(spell or '',color_arr['spellcol'])
+					end
 				elseif table.contains(fields,'ability') then
 					ability = jobabilities[abil_ID]['english']
 					if msg_ID == 379 then ability = 'Magic Burst '..ability end

--- a/addons/battlemod/event_action.lua
+++ b/addons/battlemod/event_action.lua
@@ -220,9 +220,9 @@ function event_action(act)
 						spell = 'Magic Burst '..spell
 					end
 					if actor_table['is_npc'] then
-						spell = color_it(spell or '',color_arr['mobspellcol'])
+						spell = spell and color_it(spell, color_arr['mobspellcol']) or ''
 					else
-						spell = color_it(spell or '',color_arr['spellcol'])
+						spell = spell and color_it(spell, color_arr['spellcol']) or ''
 					end
 				elseif table.contains(fields,'ability') then
 					ability = jobabilities[abil_ID]['english']
@@ -261,9 +261,9 @@ function event_action(act)
 						weapon_skill = weapon_skill..' (No Effect)'
 					end
 					if actor_table['is_npc'] then
-						weapon_skill = color_it(weapon_skill or '',color_arr['mobwscol'])
+						weapon_skill = weapon_skill and color_it(weapon_skill, color_arr['mobwscol']) or ''
 					else
-						weapon_skill = color_it(weapon_skill or '',color_arr['wscol'])
+						weapon_skill = weapon_skill and color_it(weapon_skill, color_arr['wscol']) or ''
 					end
 				elseif msg_ID == 303 then
 					ability = 'Divine Seal'

--- a/addons/battlemod/static_vars.lua
+++ b/addons/battlemod/static_vars.lua
@@ -51,7 +51,7 @@ p0=501,p1=204,p2=410,p3=492,p4=259,p5=260,
 a10=205,a11=359,a12=167,a13=038,a14=125,a15=185,
 a20=429,a21=257,a22=200,a23=481,a24=483,a25=208,
 mobdmg=0,mydmg=0,partydmg=0,allydmg=0,otherdmg=0,
-spellcol=0,abilcol=0,wscol=0,mobwscol=0,statuscol=191,itemcol=256,enfeebcol=475}
+spellcol=0,abilcol=0,wscol=0,mobwscol=0,mobspellcol=0,statuscol=191,itemcol=256,enfeebcol=475}
 
 filter = {}
 wearing = {}
@@ -357,6 +357,7 @@ default_colors = [[
 		<otherdmg>0</otherdmg>
 		
 		<spellcol>0</spellcol>
+		<mobspellcol>0</mobspellcol>
 		<abilcol>0</abilcol>
 		<wscol>0</wscol>
 		<mobwscol>0</mobwscol>


### PR DESCRIPTION
Add color setting for NPC magic casting (enemies, automatons). 
New setting is available in colors.xml file:
        < mobspellcol >0< /mobspellcol >
This will change color of spells casted by NPCs (primarily any mob, but also player's automaton).
To set the color of player casted magic, use currently present setting:
        < spellcol >0< /spellcol >
