### PR TITLE
Update findAll.lua

### DIFF
--- a/addons/findAll/findAll.lua
+++ b/addons/findAll/findAll.lua
@@ -150,7 +150,8 @@ function search(query, export)
     end
 
     log('Searching: '..query:concat(' '))
-
+    sleep(10)
+    
     local no_results   = true
     local sorted_names = global_storages:keyset():sort()
                                                  :reverse()
@@ -208,6 +209,7 @@ function search(query, export)
 
                     for _, result in ipairs(results) do
                         log(result)
+                        sleep(10)
                     end
                 end
             end


### PR DESCRIPTION
added sleep(10) in 2 places because the chat log output was going way too fast and causing things to appear out of order. I tested this on mine and it fixed this order issue.
