### PR TITLE
Update timestamp.lua

### DIFF
--- a/addons/timestamp/timestamp.lua
+++ b/addons/timestamp/timestamp.lua
@@ -101,12 +101,12 @@ end
 windower.register_event('incoming text', function(original, modified, mode, newmode)
     if modified ~= '' and not modified:find('^[%s]+$') then
         if mode == 144 then -- 144 works as 150 but the enter prompts are ignored.
-            mode     = 150
+            newmode  = 150
             modified = modified:gsub(string.char(0x7f, 0x31)..'$', '')
         end
 
         if mode == 150 then -- 150 automatically indents new lines. 151 works the same way but with no indentation. redirect to 151 and manually add the ideographic space.
-            mode     = 151
+            newmode  = 151
             modified = modified:gsub('([^'..lead_bytes_pattern..'])['..string.char(0x07)..'\n]', '%1\n'..string.char(0x81, 0x40))
         end
 

--- a/addons/timestamp/timestamp.lua
+++ b/addons/timestamp/timestamp.lua
@@ -98,7 +98,7 @@ function make_timestamp(format)
     return os.date((format:gsub('%${([%l%d_]+)}', constants)))
 end
 
-windower.register_event('incoming text', function(original, modified, mode)
+windower.register_event('incoming text', function(original, modified, mode, newmode)
     if modified ~= '' and not modified:find('^[%s]+$') then
         if mode == 144 then -- 144 works as 150 but the enter prompts are ignored.
             mode     = 150
@@ -119,7 +119,7 @@ windower.register_event('incoming text', function(original, modified, mode)
         end
     end
 
-    return modified, mode
+    return modified, newmode
 end)
 
 windower.register_event('addon command', function(...)


### PR DESCRIPTION
needed to return newmode rather than the old one since arcon added original/modified ones. It was overwriting ffocolor's chat tab placement functionality.
