### PR TITLE
PetTP, BattleMod fixes

### DIFF
--- a/addons/PetTP/PetTP.lua
+++ b/addons/PetTP/PetTP.lua
@@ -393,9 +393,11 @@ windower.register_event('load', function()
             windower.add_to_chat(8, 'Pet index: '..windower.ffxi.get_mob_by_target('pet').index)
         end
     end
-    if update_pet() == true then
-        make_visible()
-        printpettp()
+    if windower.ffxi.get_player() then
+        if update_pet() == true then
+            make_visible()
+            printpettp()
+        end
     end
 end)
 

--- a/addons/battlemod/battlemod.lua
+++ b/addons/battlemod/battlemod.lua
@@ -469,7 +469,7 @@ windower.register_event('incoming chunk',function (id,original,modified,is_injec
 		end
 		
 ------------- JOB INFO ----------------
-	elseif id == 0x06F then
+--[[	elseif id == 0x06F then
 		local result = data:byte(6,6)
 		if result == 1 then
 			windower.add_to_chat(8,' -------------- HQ Tier 1! --------------')
@@ -478,6 +478,7 @@ windower.register_event('incoming chunk',function (id,original,modified,is_injec
 		elseif result == 3 then
 			windower.add_to_chat(8,' -------------- HQ Tier 3! --------------')
 		end
+]]		
 	elseif id == 0x01B then
 		filterload(res.jobs[data:byte(5)].short)
 	end


### PR DESCRIPTION
PetTP: Don't check for pet before player has loaded (happens on initial load at title screen)
BattleMod: HQ Tier code isn't correct and needs further testing
