### PR TITLE
Cancel v1.0

### DIFF
--- a/addons/cancel/cancel.lua
+++ b/addons/cancel/cancel.lua
@@ -25,146 +25,31 @@
 --SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 _addon.name = 'Cancel'
-_addon.version = '0.6'
+_addon.version = '1.0'
 _addon.author = 'Byrth'
 _addon.commands = {'cancel'}
 
-file = require 'files'
+res = require 'resources'
 
-statusFile = file.new('../../plugins/resources/status.xml')
-
------------------------------------------------------------------------------------
---Name: parse_resources()
---Args:
----- lines_file (table of strings) - Table loaded with readlines() from an opened file
------------------------------------------------------------------------------------
---Returns:
----- Table of subtables indexed by their id (or index).
----- Subtables contain the child text nodes/attributes of each resources line.
-----
----- Child text nodes are given the key "english".
----- Attributes keyed by the attribute name, for example:
----- <a id="1500" a="1" b="5" c="10">15</a>
----- turns into:
----- completed_table[1500]['a']==1
----- completed_table[1500]['b']==5
----- completed_table[1500]['c']==10
----- completed_table[1500]['english']==15
-----
----- There is also currently a field blacklist (ignore_fields) for the sake of memory bloat.
------------------------------------------------------------------------------------
-function parse_resources(lines_file)
-	local ignore_fields = {['duration']=true,['de']=true,['fr']=true,['jp']=true,['enLog']=true}
-	local completed_table = {}
-	local counter = 0
-	local find = string.find
-	for i in ipairs(lines_file) do
-		local str = tostring(lines_file[i])
-		local g,h,typ,key = find(str,'<(%w+) id="(%d+)" ')
-		if typ == 's' then
-			g,h,key = find(str,'index="(%d+)" ')
-		end
-		if key ~=nil then
-			completed_table[tonumber(key)]={}
-			local q = 1
-			while q <= str:len() do
-				local a,b,ind,val = find(str,'(%w+)="([^"]+)"',q)
-				if ind~=nil then
-					if not ignore_fields[ind] then
-						if str2bool(val) then
-							completed_table[tonumber(key)][ind] = str2bool(val)
-						else
-							completed_table[tonumber(key)][ind] = val:gsub('&quot;','\42'):gsub('&apos;','\39')
-						end
-					end
-					q = b+1
-				else
-					q = str:len()+1
-				end
-			end
-			local k,v,english = find(str,'>([^<]+)</')
-			if english~=nil then
-				completed_table[tonumber(key)]['english']=english
-			end
-		end
-	end
-
-	return completed_table
-end
-
------------------------------------------------------------------------------------
---Name: str2bool()
---Args:
----- input (string) - Value that might be true or false
------------------------------------------------------------------------------------
---Returns:
----- boolean or nil. Defaults to nil if input is not true or false.
------------------------------------------------------------------------------------
-function str2bool(input)
-	-- Used in the options_load() function
-	if input:lower() == 'true' then
-		return true
-	elseif input:lower() == 'false' then
-		return false
-	else
-		return nil
-	end
-end
-
------------------------------------------------------------------------------------
---Name: strip()
---Args:
----- name (string): Name to be slugged
------------------------------------------------------------------------------------
---Returns:
----- string with a gsubbed version of name that removes non-letter/numbers and
--------- forces it to lower case.
------------------------------------------------------------------------------------
-function strip(name)
-	return name:gsub('[^%a]',''):lower()
-end
-
-statuses = parse_resources(statusFile:readlines())
 name_index = {}
-language = 'english' --windower.ffxi.get_info().language
-
-for i,v in pairs(statuses) do
-	local stripped = strip(v.english)
-	if name_index[stripped] then
-		if type(name_index[stripped]) == 'table' then
-			name_index[stripped][#name_index[stripped]+1] = tonumber(i)
-		else
-			local tempval = name_index[stripped]
-			name_index[stripped] = {tempval,tonumber(i)}
-		end
-	else
-		name_index[strip(v.english)] = tonumber(i) -- Need to add something to deal with ambiguous cases
-	end
-end
+language = windower.ffxi.get_info().language:lower()
 
 
 windower.register_event('addon command',function (...)
 	local command = table.concat({...},' ')
-	local status_id = tonumber(command) or name_index[strip(command)]
-	if not status_id then return end
-	
-	local buffs = windower.ffxi.get_player().buffs
-	
-	for _,v in pairs(buffs) do
-		if type(status_id) == 'table' then
-			for _,m in pairs(status_id) do
-				if v == m then
-					cancel(v)
-					return
-				end
+	if not command then return end
+	local status_id_tab = command:split(',')
+	status_id_tab.n = nil
+	local ids = {}
+	local buffs = {}
+	for _,v in pairs(windower.ffxi.get_player().buffs) do
+		for _,r in pairs(status_id_tab) do
+			if windower.wc_match(res.buffs[v][language],r) or windower.wc_match(tostring(v),r) then
+				cancel(v)
+				break
 			end
-		elseif status_id == v then
-			cancel(status_id)
-			return
 		end
 	end
-	
-	windower.add_to_chat(123,'Cancel: Status '..statuses[status_id].english..' not found active in your buff list.')
 end)
 
 function cancel(id)


### PR DESCRIPTION
Updated cancel to use the resources library, added wildcard matching
(for numbers/names), adjusted it so it accepts multiple buff names/IDs
simultaneously (delimited by commas). Uses the language of the client
for buff names.
