### PR TITLE
GearSwap - Change how disabling equipment works.

### DIFF
--- a/addons/GearSwap/flow.lua
+++ b/addons/GearSwap/flow.lua
@@ -118,7 +118,7 @@ function equip_sets(swap_type,ts,...)
         -- if there's no swapping to be done because the user is a monster.
         
         for i,v in pairs(short_slot_map) do
-            if equip_list[i] and (disable_table[v] or encumbrance_table[v]) then
+            if equip_list[i] and encumbrance_table[v] then
                 not_sent_out_equip[i] = equip_list[i]
             end
         end
@@ -157,7 +157,7 @@ function equip_sets(swap_type,ts,...)
                         out_str = out_str..'  Emptying slot'
                     end
                     windower.add_to_chat(8,'GearSwap (Debugging): '..out_str)
-                elseif equip_next[i] and not disable_table[i] and not encumbrance_table[i] then
+                elseif equip_next[i] and not encumbrance_table[i] then
                     windower.debug('attempting to set gear. Order: '..tostring(_)..'  Slot ID: '..tostring(i)..'  Inv. ID: '..tostring(equip_next[i]))
                     if not _settings.demo_mode then
                         if equip_next[i].slot ~= empty then

--- a/addons/GearSwap/helper_functions.lua
+++ b/addons/GearSwap/helper_functions.lua
@@ -160,15 +160,17 @@ end
  
 -----------------------------------------------------------------------------------
 ----Name: is_slot_key(k)
--- Checks to see if key 'k' is known in the slot_map array.
+-- Checks to see if key 'k' is known in the slot_map array, and that slot has not
+-- been disabled.
 ----Args:
 -- k - A key to a gear slot in a gear table.
 -----------------------------------------------------------------------------------
 ----Returns:
--- True if the key is recognized in the slot_map table; otherwise false.
+-- True if the key is recognized in the slot_map table, and that slot is enabled;
+-- otherwise false.
 -----------------------------------------------------------------------------------
 function is_slot_key(k)
-    return slot_map[k]
+    return slot_map[k] and not disable_table[slot_map[k]]
 end
  
  


### PR DESCRIPTION
Prevent adding to the equip_list, rather than preventing the equip_list from being implemented. This allows `enable()` and `disable()` to have immediate and dynamic effects in user code.
