### PR TITLE
Battlemod: fix lua error when act.action is nil

### DIFF
--- a/addons/battlemod/parse_action_packet.lua
+++ b/addons/battlemod/parse_action_packet.lua
@@ -182,6 +182,7 @@ function parse_action_packet(act)
                 elseif m.message == 437 or m.message == 438 then m.simp_name = act.action.name..' (JAs and TP)'
                 elseif m.message == 439 or m.message == 440 then m.simp_name = act.action.name..' (SPs, JAs, TP, and MP)'
                 elseif T{252,265,268,269,271,272,274,275}:contains(m.message) then m.simp_name = 'Magic Burst! '..act.action.name
+                elseif not act.action then m.simp_name = ''
                 else m.simp_name = act.action.name or ''
                 end
 


### PR DESCRIPTION
Occurs from status effect generating aoes, like Graupel Formations.
I'm open to suggestions whether to assign a generic action to this like 'AOE' so it's not just blank, but I can't really think what to call the effect. 
But what it shows up as isn't so bad, although the double spacing in there is a little weird.

Graupel Formation   -> {2} Snicky, Garuda (Frost)
