### PR TITLE
BattleMod: fix attempt to index field 'action' (a nil value)

### DIFF
--- a/addons/battlemod/parse_action_packet.lua
+++ b/addons/battlemod/parse_action_packet.lua
@@ -182,7 +182,9 @@ function parse_action_packet(act)
                 elseif m.message == 437 or m.message == 438 then m.simp_name = act.action.name..' (JAs and TP)'
                 elseif m.message == 439 or m.message == 440 then m.simp_name = act.action.name..' (SPs, JAs, TP, and MP)'
                 elseif T{252,265,268,269,271,272,274,275}:contains(m.message) then m.simp_name = 'Magic Burst! '..act.action.name
-                elseif not act.action then m.simp_name = ''
+                elseif not act.action then 
+                   m.simp_name = ''
+                   act.action = {}
                 else m.simp_name = act.action.name or ''
                 end
 


### PR DESCRIPTION
Not sure what caused this. seems like :gsub is resolving stuff it doesn't need to use, which is causing reference errors due to nil value variables that aren't expected to be populated for the message. i.e. the error shows on a ${spell} replacement, when the output line has no ${spell}.  I'm open to other suggestions for fixing this.
