### PR TITLE
GearSwap/Mote-Libs: Allow sidecar files in the gear/ subdirectory to not...

### DIFF
--- a/addons/GearSwap/libs/Mote-Utility.lua
+++ b/addons/GearSwap/libs/Mote-Utility.lua
@@ -551,7 +551,9 @@ function load_sidecar(job)
 	if not job then return false end
 	
 	-- filename format example for user-local files: whm_gear.lua, or playername_whm_gear.lua
-	local filenames = {player.name..'_'..job..'_gear.lua', job..'_gear.lua', 'gear/'..player.name..'_'..job..'_gear.lua', 'gear/'..job..'_gear.lua'}
+	local filenames = {player.name..'_'..job..'_gear.lua', job..'_gear.lua',
+		'gear/'..player.name..'_'..job..'_gear.lua', 'gear/'..job..'_gear.lua',
+		'gear/'..player.name..'_'..job..'.lua', 'gear/'..job..'.lua'}
 	return optional_include(filenames)
 end
 


### PR DESCRIPTION
... be decorated with _gear.
