### PR TITLE
GearSwap/Mote-Libs:

### DIFF
--- a/addons/GearSwap/libs/Mote-Include.lua
+++ b/addons/GearSwap/libs/Mote-Include.lua
@@ -197,7 +197,9 @@ init_include()
 -- versions of this function.
 if not file_unload then
 	file_unload = function()
-		if job_file_unload then
+		if user_unload then
+			user_unload()
+		elseif job_file_unload then
 			job_file_unload()
 		end
 		_G[(binds_on_unload and 'binds_on_unload') or 'global_on_unload']()
@@ -286,6 +288,9 @@ function pretarget(spell)
 end
 
 function precast(spell)
+	if state.Buff[spell.english] ~= nil then
+		state.Buff[spell.english] = true
+	end
 	handle_actions(spell, 'precast')
 end
 
@@ -294,6 +299,9 @@ function midcast(spell)
 end
 
 function aftercast(spell)
+	if state.Buff[spell.english] ~= nil then
+		state.Buff[spell.english] = not spell.interrupted or buffactive[spell.english]
+	end
 	handle_actions(spell, 'aftercast')
 end
 
@@ -966,6 +974,8 @@ function sub_job_change(newSubjob, oldSubjob)
 	if job_sub_job_change then
 		job_sub_job_change(newSubjob, oldSubjob)
 	end
+	
+	send_command('gs c update')
 end
 
 
@@ -1001,6 +1011,10 @@ end
 function buff_change(buff, gain)
 	-- Init a new eventArgs
 	local eventArgs = {handled = false}
+
+	if state.Buff[buff] ~= nil then
+		state.Buff[buff] = gain
+	end
 
 	-- Allow a global function to be called on buff change.
 	if user_buff_change then

--- a/addons/GearSwap/libs/Mote-SelfCommands.lua
+++ b/addons/GearSwap/libs/Mote-SelfCommands.lua
@@ -189,6 +189,7 @@ function handle_cycle(cmdParams)
 	-- identifier for the field we're changing
 	local paramField = cmdParams[1]
 	local modeField = paramField
+	local order = (cmdParams[2] and S{'reverse', 'backwards', 'r'}:contains(cmdParams[2]:lower()) and 'backwards') or 'forward'
 
 	if paramField:endswith('mode') or paramField:endswith('Mode') then
 		-- Remove 'mode' from the end of the string
@@ -219,9 +220,16 @@ function handle_cycle(cmdParams)
 	end
 
 	-- Increment to the next index in the available modes.
-	index = index + 1
-	if index > #modeList then
-		index = 1
+	if order == 'forward' then
+		index = index + 1
+		if index > #modeList then
+			index = 1
+		end
+	else
+		index = index - 1
+		if index < 1 then
+			index = #modeList
+		end
 	end
 
 	-- Determine the new mode value based on the index.


### PR DESCRIPTION
Call update on subjob change.  In particular, this will force a refresh of state.Buff vars.
Automatic handling of state.Buff table updates.
Prefer user_unload for user version of this function, though keep job_file_unload as a fallback.
Allow an extra parameter in a cycle command to cause a mode list to be traversed backwards.
