### PR TITLE
[findAll] convert command line params to UTF-8

### DIFF
--- a/addons/findAll/findAll.lua
+++ b/addons/findAll/findAll.lua
@@ -365,6 +365,11 @@ windower.register_event('addon command', function(...)
         local query  = L{}
         local export = nil
 
+        -- convert command line params (SJIS) to UTF-8
+        for i, elm in ipairs(params) do
+            params[i] = windower.from_shift_jis(elm)
+        end
+
         while params:length() > 0 and params[1]:match('^[:!]%a+$') do
             query:append(params:remove(1))
         end


### PR DESCRIPTION
In JP client, findAll had not worked because character encoding is differ.
Now command line params are encoded to UTF-8.
