### PR TITLE
Update parse_action_packet.lua

### DIFF
--- a/addons/battlemod/parse_action_packet.lua
+++ b/addons/battlemod/parse_action_packet.lua
@@ -367,11 +367,13 @@ end
 
 function assemble_targets(actor,targs,category,msg)
     local targets = {}
-    for i,v in pairs(targs) do
-    -- Done in two loops so that the ands and commas don't get out of place.
-    -- This loop filters out unwanted targets.
-        if check_filter(actor,v,category,msg) then
-            targets[#targets+1] = v
+    if (targs) then
+        for i,v in pairs(targs) do
+        -- Done in two loops so that the ands and commas don't get out of place.
+        -- This loop filters out unwanted targets.
+            if check_filter(actor,v,category,msg) then
+                targets[#targets+1] = v
+            end
         end
     end
     


### PR DESCRIPTION
Not often....but somewhat regularly I get a runtime error on line 370 (371 now) about pairs() complaining that targs is nil instead of a table.
