### PR TITLE
Update fields.lua

### DIFF
--- a/addons/libs/packets/fields.lua
+++ b/addons/libs/packets/fields.lua
@@ -2125,7 +2125,7 @@ fields.incoming[0x0C8] = L{
     {ctype='unsigned char',     label='_unknown1'},                             -- 04
     {ctype='data[3]',           label='_junk1'},                                -- 05
     {ref=types.alliance_member, count=18},                                      -- 08
-    {ctype='data[24]',          label='_unknown2',          const=''},          -- E0   Always 0?
+    {ctype='data[24]',          label='_unknown3',          const=''},          -- E0   Always 0?
 }
 
 types.check_item = L{


### PR DESCRIPTION
It's confusing to have an _unknown2 for each member,  in addition to one for the packet. I suggest renaming the last one to _unknown3
