### PR TITLE
GearSwap pet_update changes

### DIFF
--- a/addons/GearSwap/gearswap.lua
+++ b/addons/GearSwap/gearswap.lua
@@ -470,6 +470,17 @@ windower.register_event('incoming chunk',function(id,data,modified,injected,bloc
             refresh_globals()
             equip_sets('indi_change',nil,temp_indi,false)
         end
+
+        local subj_ind = data:unpack('H', 0x35) / 8
+        if subj_ind == 0 and pet.isvalid then
+            if not next_packet_events then next_packet_events = {sequence_id = data:unpack('H',3)} end
+            refresh_globals()
+            pet.isvalid = false
+            next_packet_events.pet_change = {pet = table.reassign({},pet)}
+        elseif subj_ind ~= 0 and not pet.isvalid then
+            if not next_packet_events then next_packet_events = {sequence_id = data:unpack('H',3)} end
+            next_packet_events.pet_change = {subj_ind = subj_ind}
+        end
     elseif id == 0x044 then
         -- No idea what this is doing
     elseif id == 0x050 then
@@ -531,25 +542,6 @@ windower.register_event('incoming chunk',function(id,data,modified,injected,bloc
             if current_skill then
                 player.skills[to_windower_api(current_skill.english)] = skill
             end
-        end
-    elseif id == 0x067 then
-        local flag_1 = data:byte(5)
-        local flag_2 = data:byte(6)
-        local owner_ind = data:unpack('H',13)
-        local subj_ind = data:unpack('H',7)
-                
-        if flag_1 == 3 and flag_2 == 5 and windower.ffxi.get_player().index == owner_ind and not pet.isvalid then
-            if not next_packet_events then next_packet_events = {sequence_id = data:unpack('H',3)} end
-            next_packet_events.pet_change = {subj_ind = subj_ind}
-        elseif flag_1 == 4 and flag_2 == 5 and windower.ffxi.get_player().index == subj_ind then
-            if not next_packet_events then next_packet_events = {sequence_id = data:unpack('H',3)} end
-            refresh_globals()
-            pet.isvalid = false
-            next_packet_events.pet_change = {pet = table.reassign({},pet)}
-        elseif flag_2 == 7 and windower.ffxi.get_player().index == subj_ind and not pet.isvalid then
-            if not next_packet_events then next_packet_events = {sequence_id = data:unpack('H',3)} end
-            pet.isvalid = true
-            next_packet_events.pet_change = {subj_ind = owner_ind}
         end
     elseif id == 0x0DF then
         player.vitals.hp = data:unpack('I',9)

--- a/addons/GearSwap/refresh.lua
+++ b/addons/GearSwap/refresh.lua
@@ -263,7 +263,7 @@ function refresh_player(dt,user_event_flag)
                 pet.element = res.elements[-1][language] -- Physical
             end
         else
-            table.reassign(pet, {isvalid=true})
+            table.reassign(pet, {isvalid=false})
         end
     else
         table.reassign(pet, {isvalid=false})

--- a/addons/libs/packets/fields.lua
+++ b/addons/libs/packets/fields.lua
@@ -2064,18 +2064,16 @@ fields.incoming[0x065] = L{
 fields.incoming[0x067] = L{
 -- The length of this packet is 24, 28, 36 or 40 bytes, featuring a 0, 4, 8, 12, or 16 byte name field.
 
--- The Mask seem to be a bitpacked combination of a mask indicating which information is updated and
---    a field indicating the length of the name in the packet.
+-- The Mask is a bitpacked combination of a number indicating the type of information in the packet and
+--    a field indicating the length of the packet.
 
--- The information below should probably be re-verified, but:
--- 44 07 is used for pets with names that are 4-7 characters (8 character field). It updates pet TP but not Owner Index.
--- 84 07 is used for pets with names that are 8-11 characters (12 character field). It updates pet TP but not Owner Index.
--- C4 07 is used for pets with even longer names (>11 characters, 16 character field). It updates pet TP but not Owner Index.
--- 44 08 is used for pets with extremely long names. It updates pet TP but not Owner Index.
+-- The lower 6 bits of the Mask is the type of packet:
+-- 2 occurs often even with no pet, contains player index, id and main job level
+-- 3 identifies (potential) pets and who owns them
+-- 4 gives status information about your pet
 
--- 02 09 is sent regularly to update owner information (about yourself). This might contain information if you are charmed.
--- 03 05 is sent when summoning pets, Trust NPCs, etc.
--- 04 05 is sent when releasing pets (unknown for Trust NPCs)
+-- The upper 10 bits of the Mask is the length in bytes of the data excluding the header and any padding
+--    after the pet name.
 
     {ctype='unsigned short',    label='Mask'},                                  -- 04
     {ctype='unsigned short',    label='Pet Index',          fn=index},          -- 06


### PR DESCRIPTION
I figured out some more information about the 0x67 packet and it's not really a reliable way of determining when you gain or lose a pet. It's really just a status update for you pet but it doesn't guarantee that information about that pet is available yet. The 0x37 packet it a reliable way to get your current pet index and it also allows for the pet_change event to properly trigger when zoning. I also changed the refresh of the global pet table to only set pet.isvalid true when there is actually pet information available because it doesn't make any sense otherwise.
