### PR TITLE
Update fields.lua

### DIFF
--- a/addons/libs/packets/fields.lua
+++ b/addons/libs/packets/fields.lua
@@ -1719,14 +1719,13 @@ fields.incoming._func[0x04B].base = L{
     {ctype='signed char',       label='Delivery Slot'},                         -- 06   This goes left to right and then drops down a row and left to right again. Value is 00 through 07
                                                                                 --    01 if Type is 06, otherwise FF
                                                                                 --    06 Type always seems to come in a pair, this field is only 01 for the first packet
-    {ctype='signed char',       label='_unknown2'},                               
-    {ctype='signed int',        label='_unknown3',          const=-1},          -- 07   Always FF FF FF FF?
-    {ctype='signed char',       label='_unknown4'},                             -- 0C   When in a 0x0D/0x0E type, 01 grants request to open inbox/outbox. With FA you get "Please try again later"
-    {ctype='signed char',       label='Packet Number'},                         -- 0D   02 and 03 observed
-    {ctype='signed char',       label='_unknown5'},                             -- 0E   FF FF observed
-    {ctype='signed char',       label='_unknown6'},                             -- 0F   FF FF observed
-    {ctype='unsigned int',      label='_unknown7'},                             -- 10   06 00 00 00 and 07 00 00 00 observed - (06 was for the first packet and 07 was for the second)
-                                                                                -- 10   00 00 00 00 also observed    
+    {ctype='signed char',       label='_unknown2'},                             -- 07   Always FF FF FF FF?  
+    {ctype='signed int',        label='_unknown3',          const=-1},          -- 0C   When in a 0x0D/0x0E type, 01 grants request to open inbox/outbox. With FA you get "Please try again later"
+    {ctype='signed char',       label='_unknown4'},                             -- 0D   02 and 03 observed
+    {ctype='signed char',       label='Packet Number'},                         -- 0E   FF FF observed
+    {ctype='signed char',       label='_unknown5'},                             -- 0F   FF FF observed
+    {ctype='signed char',       label='_unknown6'},                             -- 10   06 00 00 00 and 07 00 00 00 observed - (06 was for the first packet and 07 was for the second)
+    {ctype='unsigned int',      label='_unknown7'},                             -- 10   00 00 00 00 also observed
 }
 
 -- If the type is 0x01, 0x04, 0x06, 0x08 or 0x0A, these fields appear in the packet in addition to the base. Maybe more

--- a/addons/libs/packets/fields.lua
+++ b/addons/libs/packets/fields.lua
@@ -1717,8 +1717,9 @@ fields.incoming._func[0x04B].base = L{
     {ctype='unsigned char',     label='Type',               fn=e+{'delivery'}}, -- 04
     {ctype='unsigned char',     label='_unknown1'},                             -- 05   FF if Type is 05, otherwise 01
     {ctype='signed char',       label='Delivery Slot'},                         -- 06   This goes left to right and then drops down a row and left to right again. Value is 00 through 07
-    {ctype='signed char',       label='_unknown2'},                             -- 06?   01 if Type is 06, otherwise FF
-                                                                                -- 06?   06 Type always seems to come in a pair, this field is only 01 for the first packet
+                                                                                --    01 if Type is 06, otherwise FF
+                                                                                --    06 Type always seems to come in a pair, this field is only 01 for the first packet
+    {ctype='signed char',       label='_unknown2'},                               
     {ctype='signed int',        label='_unknown3',          const=-1},          -- 07   Always FF FF FF FF?
     {ctype='signed char',       label='_unknown4'},                             -- 0C   When in a 0x0D/0x0E type, 01 grants request to open inbox/outbox. With FA you get "Please try again later"
     {ctype='signed char',       label='Packet Number'},                         -- 0D   02 and 03 observed

--- a/addons/libs/packets/fields.lua
+++ b/addons/libs/packets/fields.lua
@@ -1663,16 +1663,9 @@ fields.incoming._func[0x044][0x17] = L{
 -- Delivery Item
 fields.incoming._func[0x04B] = {}
 fields.incoming[0x04B] = function()
---    local full = S{0x01, 0x06, 0x08, 0x0A} -- This does not catch all FULL/long packets.
+    local full = S{0x01, 0x04, 0x06, 0x08, 0x0A} -- This might not catch all packets with 'slot-info' (extra 68 bytes)
     return function(data)
-        if (data:length() == 88) then
-            -- return the 88 byte chunk
-            return fields.incoming._func[0x04B].slot
-        end
---        return full:contains(data:byte(5, 5)) and fields.incoming._func[0x04B].slot or fields.incoming._func[0x04B].base
-        -- return the 20 byte chunk
-        return fields.incoming._func[0x04B].base
-    end
+        return full:contains(data:byte(5, 5)) and fields.incoming._func[0x04B].slot or fields.incoming._func[0x04B].base
 end()
 
 enums.delivery = {


### PR DESCRIPTION
Fix:
  As it was, fields.lua was generating  a runtime error when trying to build/parse incoming 4B chunks.

Suggested changes:
- in outgoing 0x4D, renaming "Manipulation Type" to just "Type" to be consistent with incoming 0x4B's "Type"
- In incoming 0x4B: some of the comments are out of sequence.
- in incoming 0x4B, _unknown5 is listed twice. Renamed to 6 and renumbered all the following unknowns.
- in incoming 0x4B's function:  only processing the "FULL" 88-byte packet when Type matches the hardcoded  Set does not seem like the right thing to do, as there are other Type numbers with an 88-type packet. Plus there might be more. Changed function to process it differently depending on length of data instead. 
- in incoming 0x4B, renamed "Sender Name" to "Player Name" as the field is used for both for senders and recipients (depending on whether this is for inbox or outbox)

Other issues:
- Some of the existing comments with observed values are not accurate (or no longer accurate)
- 'Packet number' field does not seem to be a packet number.  unknown4 seems to be for a packet number for when they come in pairs.

There's more to do, but I wanted to push this as is for now.
