### PR TITLE
obiaway update

### DIFF
--- a/addons/obiaway/Obiaway.lua
+++ b/addons/obiaway/Obiaway.lua
@@ -69,13 +69,13 @@ settings = config.load(default_settings)
 
 -- Accepts msg as a string or a table
 function obi_output(msg)
-        windower.add_to_chat(209, msg)
+	windower.add_to_chat(209, msg)
 end
 
 windower.register_event('addon command', function()
 
 	return function(command, ...)
-	    command = command:lower() or 'help'
+		command = command:lower() or 'help'
         local params = {...}
 
 		if command == 'help' or command == 'h' then
@@ -112,7 +112,7 @@ windower.register_event('addon command', function()
 end())
 
 function get_obis_in_inventory()
-    obis = {}
+	obis = {}
     items = windower.ffxi.get_items()
     inv = items.inventory
     if not inv then return end

--- a/addons/obiaway/Obiaway.lua
+++ b/addons/obiaway/Obiaway.lua
@@ -50,6 +50,10 @@
 -- is called before inventory has loaded and returns nothing.
 --
 -- 3. Obi is not moved when currently equipped.
+--
+-- 4. When using the get all or put all command, obiaway will still
+-- autosort obi if you're not in town. On to-do.
+--
 
 _addon.name = "Obiaway"
 _addon.author = "ReaperX, onetime"
@@ -72,66 +76,63 @@ function obi_output(msg)
     windower.add_to_chat(209, msg)
 end
 
-windower.register_event('addon command', function()
-
-    return function(command, ...)
-        local command = command:lower() or 'help'
-        local params = L{...}:map(string.lower)
-
-        if command == 'help' or command == 'h' then
-            obi_output("Obiaway v".._addon.version..". Authors: ".._addon.author)
-            obi_output("//(ob)iaway [options]")
-            obi_output("   (h)elp :  Displays this help text.")
-            obi_output("   (s)ort :  Automatically sorts obi.")
-            obi_output("   (g)et [ (a)ll | (n)eeded ] :  Gets obi.")
-            obi_output("   (p)ut [ (a)ll | u(n)needed ] :  Puts obi.")
-            obi_output("   (n)otify [ on | off ] :  Sets obiaway notifcations on or off.")
-            obi_output("   (l)ocation [ sack | satchel | case | wardrobe ] :  Sets inventory from which to get and put obi.")
-        elseif command == 'sort' or command == 's' then
-            obi_output("Sorting obi...")
-            auto_sort_obi()
-        elseif command == 'get' or command == 'g' then
-            if params[1] == 'all' or params [1] == 'a' then
-                obi_output('Getting all obi from %s...':format(settings.location))
-                get_all_obi(true)
-            elseif params[1] == 'needed' or params [1] == 'n' then
-                obi_output('Getting needed obi from %s...':format(settings.location))
-                get_needed_obi(true)
-            else
-                error("Invalid argument. Usage: //obiaway get [ all | needed ]")
-            end
-        elseif command == 'put' or command == 'p' then
-            if params[1] == 'all' or params [1] == 'a' then
-                obi_output('Putting all obi into %s...':format(settings.location))
-                put_all_obi(true)
-            elseif params[1] == 'unneeded' or params[1] == 'needed' or params [1] == 'n' then
-                obi_output('Putting unneeded obi into %s...':format(settings.location))
-                put_unneeded_obi(true)
-            else
-                error("Invalid argument. Usage: //obiaway put [ all | needed ]")
-            end
-        elseif command == 'notify' or command == 'n' then
-            if params[1] == 'on' then
-                settings.notify = true
-                obi_output("Obiaway notifications are now on")
-            elseif params[1] == 'off' then
-                settings.notify = false
-                obi_output("Obiaway notifications are now off.")
-            else
-                error("Invalid argument. Usage: //obiaway notify [ on | off ]")
-            end
-        elseif command == 'location' or command == 'l' then
-            if S{'sack','case','satchel','wardrobe'}:contains(params[1]) then
-                settings.location = params[1]
-                obi_output("Obiaway location set to: %s":format(settings.location))
-            else
-                error("Invalid argument. Usage: //obiaway location [ sack | satchel | case | wardrobe ]")
-            end
+windower.register_event('addon command', function(command, ...)
+    local command = command:lower() or 'help'
+    local params = L{...}:map(string.lower)
+    
+    if command == 'help' or command == 'h' then
+        obi_output("Obiaway v".._addon.version..". Authors: ".._addon.author)
+        obi_output("//(ob)iaway [options]")
+        obi_output("   (h)elp :  Displays this help text.")
+        obi_output("   (s)ort :  Automatically sorts obi.")
+        obi_output("   (g)et [ (a)ll | (n)eeded ] :  Gets obi.")
+        obi_output("   (p)ut [ (a)ll | u(n)needed ] :  Puts obi.")
+        obi_output("   (n)otify [ on | off ] :  Sets obiaway notifcations on or off.")
+        obi_output("   (l)ocation [ sack | satchel | case | wardrobe ] :  Sets inventory from which to get and put obi.")
+    elseif command == 'sort' or command == 's' then
+        obi_output("Sorting obi...")
+        auto_sort_obi()
+    elseif command == 'get' or command == 'g' then
+        if params[1] == 'all' or params [1] == 'a' then
+            obi_output('Getting all obi from %s...':format(settings.location))
+            get_all_obi(true)
+        elseif params[1] == 'needed' or params [1] == 'n' then
+            obi_output('Getting needed obi from %s...':format(settings.location))
+            get_needed_obi(true)
         else
-            error("Unrecognized command. See //obiaway help.")
+            error("Invalid argument. Usage: //obiaway get [ all | needed ]")
         end
+    elseif command == 'put' or command == 'p' then
+        if params[1] == 'all' or params [1] == 'a' then
+            obi_output('Putting all obi into %s...':format(settings.location))
+            put_all_obi(true)
+        elseif params[1] == 'unneeded' or params[1] == 'needed' or params [1] == 'n' then
+            obi_output('Putting unneeded obi into %s...':format(settings.location))
+            put_unneeded_obi(true)
+        else
+            error("Invalid argument. Usage: //obiaway put [ all | needed ]")
+        end
+    elseif command == 'notify' or command == 'n' then
+        if params[1] == 'on' then
+            settings.notify = true
+            obi_output("Obiaway notifications are now on")
+        elseif params[1] == 'off' then
+            settings.notify = false
+            obi_output("Obiaway notifications are now off.")
+        else
+            error("Invalid argument. Usage: //obiaway notify [ on | off ]")
+        end
+    elseif command == 'location' or command == 'l' then
+        if S{'sack','case','satchel','wardrobe'}:contains(params[1]) then
+            settings.location = params[1]
+            obi_output("Obiaway location set to: %s":format(settings.location))
+        else
+            error("Invalid argument. Usage: //obiaway location [ sack | satchel | case | wardrobe ]")
+        end
+    else
+        error("Unrecognized command. See //obiaway help.")
     end
-end())
+end)
 
 function get_obi_in_inventory()
     local obi = {}
@@ -274,7 +275,7 @@ function put_all_obi(command)
     end
 end
     
-function auto_sort_obi()
+auto_sort_obi = function()
     local cities = S{
         "Ru'Lude Gardens",
         "Upper Jeuno",
@@ -305,16 +306,18 @@ function auto_sort_obi()
         "Celennia Memorial Library",
         "Mog Garden"
     }
-    local str = ''
-    if not cities:contains(res.zones[windower.ffxi.get_info().zone].english) then
-        str = str..put_unneeded_obi(false)
-        str = str..get_needed_obi(false)
-        windower.send_command(str)
-    else  -- in town. put away all obi.
-        str = str..put_all_obi(false)
-        windower.send_command(str)
+    return function()
+        local str = ''
+        if not cities:contains(res.zones[windower.ffxi.get_info().zone].english) then
+            str = str..put_unneeded_obi(false)
+            str = str..get_needed_obi(false)
+            windower.send_command(str)
+        else  -- in town. put away all obi.
+            str = str..put_all_obi(false)
+            windower.send_command(str)
+        end
     end
-end
+end()
 
 function inTable(tbl, item)
     for key, value in pairs(tbl) do

--- a/addons/obiaway/Obiaway.lua
+++ b/addons/obiaway/Obiaway.lua
@@ -54,7 +54,7 @@
 _addon.name = "Obiaway"
 _addon.author = "ReaperX, onetime"
 _addon.version = "1.0.3"
-_addon.commands = {'obi', 'obiaway'}
+_addon.commands = {'ob', 'obiaway'}
 
 require('sets')
 require('logger')
@@ -80,33 +80,33 @@ windower.register_event('addon command', function()
 
         if command == 'help' or command == 'h' then
             obi_output("Obiaway v".._addon.version..". Authors: ".._addon.author)
-            obi_output("//(obi)away [options]")
+            obi_output("//(ob)iaway [options]")
             obi_output("   (h)elp :  Displays this help text.")
             obi_output("   (s)ort :  Automatically sorts obi.")
             obi_output("   (g)et [ (a)ll | (n)eeded ] :  Gets obi.")
-            obi_output("   (p)ut [ (a)ll | (n)eeded ] :  Puts obi.")
+            obi_output("   (p)ut [ (a)ll | u(n)needed ] :  Puts obi.")
             obi_output("   (n)otify [ on | off ] :  Sets obiaway notifcations on or off.")
             obi_output("   (l)ocation [ sack | satchel | case | wardrobe ] :  Sets inventory from which to get and put obi.")
         elseif command == 'sort' or command == 's' then
-            auto_sort_obi()
             obi_output("Sorting obi...")
+            auto_sort_obi()
         elseif command == 'get' or command == 'g' then
             if params[1] == 'all' or params [1] == 'a' then
-                get_all_obi()
                 obi_output('Getting all obi from %s...':format(settings.location))
+                get_all_obi()
             elseif params[1] == 'needed' or params [1] == 'n' then
-                get_needed_obi()
                 obi_output('Getting needed obi from %s...':format(settings.location))
+                get_needed_obi()
             else
                 error("Invalid argument. Usage: //obiaway get [ all | needed ]")
             end
         elseif command == 'put' or command == 'p' then
             if params[1] == 'all' or params [1] == 'a' then
-                put_all_obi()
                 obi_output('Putting all obi into %s...':format(settings.location))
-            elseif params[1] == 'needed' or params [1] == 'n' then
-                put_needed_obi()
-                obi_output('Putting uneeded obi into %s...':format(settings.location))
+                put_all_obi()
+            elseif params[1] == 'unneeded' or params[1] == 'needed' or params [1] == 'n' then
+                obi_output('Putting unneeded obi into %s...':format(settings.location))
+                put_unneeded_obi()
             else
                 error("Invalid argument. Usage: //obiaway put [ all | needed ]")
             end

--- a/addons/obiaway/Obiaway.lua
+++ b/addons/obiaway/Obiaway.lua
@@ -59,7 +59,7 @@
 -- addon info
 _addon.name = "Obiaway"
 _addon.author = "ReaperX, onetime"
-_addon.version = "1.0.6"
+_addon.version = "1.0.7"
 _addon.commands = {'oa', 'ob', 'obi', 'obiaway'}
 _addon.language = 'english'
 

--- a/addons/obiaway/Obiaway.lua
+++ b/addons/obiaway/Obiaway.lua
@@ -83,10 +83,10 @@ windower.register_event('addon command', function()
             obi_output("//(obi)away [options]")
             obi_output("   (h)elp :  Displays this help text.")
             obi_output("   (s)ort :  Automatically sorts obi.")
-            obi_output("   (g)et [(a)ll|(n)eeded] :  Gets obi.")
-            obi_output("   (p)ut [(a)ll|(n)eeded] :  Puts obi.")
-            obi_output("   (n)otify [on|off] :  Sets obiaway notifcations on or off.")
-            obi_output("   (l)ocation [sack|satchel|case|wardrobe] :  Sets inventory from which to get and put obi.")
+            obi_output("   (g)et [ (a)ll | (n)eeded ] :  Gets obi.")
+            obi_output("   (p)ut [ (a)ll | (n)eeded ] :  Puts obi.")
+            obi_output("   (n)otify [ on |off ] :  Sets obiaway notifcations on or off.")
+            obi_output("   (l)ocation [ sack | satchel | case | wardrobe ] :  Sets inventory from which to get and put obi.")
         elseif command == 'sort' or command == 's' then
             auto_sort_obi()
             obi_output("Sorting obi...")
@@ -98,7 +98,7 @@ windower.register_event('addon command', function()
                 get_needed_obi()
                 obi_output('Getting needed obi from %s...':format(settings.location))
             else
-                error("Invalid argument. Usage: //obiaway get [all|needed]")
+                error("Invalid argument. Usage: //obiaway get [ all | needed ]")
             end
         elseif command == 'put' or command == 'p' then
             if params[1] == 'all' or params [1] == 'a' then
@@ -108,7 +108,7 @@ windower.register_event('addon command', function()
                 put_needed_obi()
                 obi_output('Putting uneeded obi into %s...':format(settings.location))
             else
-                error("Invalid argument. Usage: //obiaway put [all|needed]")
+                error("Invalid argument. Usage: //obiaway put [ all | needed ]")
             end
         elseif command == 'notify' or command == 'n' then
             if params[1] == 'on' then
@@ -118,14 +118,14 @@ windower.register_event('addon command', function()
                 settings.notify = false
                 obi_output("Obiaway notifications are now off.")
             else
-                error("Invalid argument. Usage: //obiaway notify [on|off]")
+                error("Invalid argument. Usage: //obiaway notify [ on | off ]")
             end
         elseif command == 'location' or command == 'l' then
             if S{'sack','case','satchel','wardrobe'}:contains(params[1]) then
                 settings.location = params[1]
                 obi_output("Obiaway location set to: %s":format(settings.location))
             else
-                error("Invalid argument. Usage: //obiaway location [sack|satchel|case|wardrobe]")
+                error("Invalid argument. Usage: //obiaway location [ sack | satchel | case | wardrobe ]")
             end
         else
             error("Unrecognized command. See //obiaway help.")

--- a/addons/obiaway/Obiaway.lua
+++ b/addons/obiaway/Obiaway.lua
@@ -1,5 +1,5 @@
 -- 
--- Obiaway v1.0.7
+-- Obiaway v1.0.6
 -- 
 -- Copyright ©2013-2014, ReaperX, onetime
 -- All rights reserved.
@@ -206,11 +206,14 @@ function inventory_full(command, location)
     local items = windower.ffxi.get_items(id)
     if free_space(location) == 0 then
         if command then
+            print('fiskity fuck')
             obi_output('%s is full.':format(string.ucfirst(location)))
         elseif not tokens.inv_full_warned and id == 0 then
+            print('fuskity fook')
             tokens.inv_full_warned = true
             obi_output('%s is full.':format(string.ucfirst(location)))
         elseif not tokens.bag_full_warned then
+            print('frickity frack')
             tokens.bag_full_warned = true
             obi_output('%s is full.':format(string.ucfirst(location)))
         end
@@ -261,7 +264,7 @@ end
 --
 -- function designer: ReaperX
 function get_obi_in_inventory(location)
-	id = inv_str_to_id(location)
+    id = inv_str_to_id(location)
     local obi = {}
     local inv = windower.ffxi.get_items(id)
     if not inv then return end
@@ -349,11 +352,6 @@ end
 function get_needed_obi(command)
     if inventory_full(command) then return 0 end
     local obi = get_obi_in_inventory()
-    local obi_bag = get_obi_in_inventory(settings.location)
-    if free_space() < obi_bag["n"] then
-        obi_output('Not enough space in inventory...')
-        return 0
-    end
 
     local elements = get_all_elements()
 
@@ -363,7 +361,7 @@ function get_needed_obi(command)
             if settings.notify then
                 obi_output('Getting %s Obi from %s.':format(name, settings.location))
             end
-			wait(.5)
+            wait(.5)
         end
     end
 
@@ -373,10 +371,6 @@ end
 function put_unneeded_obi(command)
     if inventory_full(command, settings.location) then return 0 end
     local obi = get_obi_in_inventory()
-    if free_space(settings.location) < obi["n"] then
-        obi_output('Not enough space in %s...':format(settings.location))
-        return 0
-    end
 
     local elements = get_all_elements()
 
@@ -386,7 +380,7 @@ function put_unneeded_obi(command)
             if settings.notify then
                 obi_output('Putting %s Obi away into %s.':format(name, settings.location))
             end
-			wait(.5)
+            wait(.5)
         end
     end
 
@@ -411,11 +405,11 @@ function get_all_obi(command)
             if settings.notify then
                 obi_output('Getting %s Obi from %s.':format(name, settings.location))
             end
-			wait(.5)
+            wait(.5)
         end
     end
-	
-	return 1
+    
+    return 1
 end
 
 function put_all_obi(command)
@@ -434,11 +428,11 @@ function put_all_obi(command)
             if settings.notify then
                 obi_output('Putting %s Obi away into %s.':format(name, settings.location))
             end
-			wait(.5)
+            wait(.5)
         end
     end
 
-	return 1
+    return 1
 end
 
 -- function called on automatic events. sorts obi based on location.
@@ -515,9 +509,9 @@ windower.register_event('addon command', function(command, ...)
                 settings.location = params[2]
                 obi_output("Obiaway location set to: %s":format(settings.location))
             else
-				obi_output('Putting unneeded obi into %s...':format(settings.location))
-				put_unneeded_obi(true)
-			end
+                obi_output('Putting unneeded obi into %s...':format(settings.location))
+                put_unneeded_obi(true)
+            end
         else
             error("Invalid argument. Usage: //obiaway put [ all | needed ] [ sack | satchel | case | wardrobe ]")
         end

--- a/addons/obiaway/Obiaway.lua
+++ b/addons/obiaway/Obiaway.lua
@@ -85,7 +85,7 @@ windower.register_event('addon command', function()
             obi_output("   (s)ort :  Automatically sorts obi.")
             obi_output("   (g)et [ (a)ll | (n)eeded ] :  Gets obi.")
             obi_output("   (p)ut [ (a)ll | (n)eeded ] :  Puts obi.")
-            obi_output("   (n)otify [ on |off ] :  Sets obiaway notifcations on or off.")
+            obi_output("   (n)otify [ on | off ] :  Sets obiaway notifcations on or off.")
             obi_output("   (l)ocation [ sack | satchel | case | wardrobe ] :  Sets inventory from which to get and put obi.")
         elseif command == 'sort' or command == 's' then
             auto_sort_obi()

--- a/addons/obiaway/Obiaway.lua
+++ b/addons/obiaway/Obiaway.lua
@@ -28,9 +28,8 @@
 -- SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 --
 -- Puts elemental obis away when they are no longer needed due
--- to day/weather/storm effect change. Uses itemizer.
--- Intended to be used in conjunection with spellcast xml that
--- moves needed obis from sack to inventory just in time. 
+-- to day/weather/storm effect change and gets elemental obi based
+-- on same conditions. Uses itemizer addon.
 -- 
 -- The advantage of this system compared to moving obis back during 
 -- aftercast is that it avoids excessive inventory movement,
@@ -38,21 +37,24 @@
 -- less likely, and timing issues with very fast spells (spell
 -- fires before obi is moved) occur at worst on the first spell
 -- not but subsequent ones.
+--
 -- Known bugs: 
+--
 -- 1. upon activation, it puts only the first unneeded
--- obi away. The function remove_unneeded_obis() tries to put all
+-- obi away. The function get_needed_obis() tries to put all
 -- of them away, but the calls to itemizer are all made instantly
 -- so only the first one is carried out. Usually, only one obi
 -- has to be removed per call, so this is not much of a problem.
+--
 -- 2. when weather changes due to zoning, get_obis_in_inventory()
--- is called before inventory has loaded and returns nothing. 
+-- is called before inventory has loaded and returns nothing.
 --
 -- 3. Obi is not moved when currently equipped.
 -- 
--- To Do: add function to turn the console_echo's on/off. 
+-- To Do: Use a loop to remove and retrieve obi for shorter code
 
 _addon.name = "Obiaway"
-_addon.author = "ReaperX"
+_addon.author = "ReaperX, onetime"
 _addon.version = "1.0.2"
 _addon.commands = {'obi', 'obiaway'}
 
@@ -117,7 +119,7 @@ function get_obis_in_inventory()
     inv = items.inventory
     if not inv then return end
     number = items.max_inventory
-    for i=1,number do 
+    for i=1,number do
         id = inv[i].id
         if ( id>=15435 and id<=15442) then
             obis["Fire"] = obis["Fire"] or (id == 15435)

--- a/addons/obiaway/Obiaway.lua
+++ b/addons/obiaway/Obiaway.lua
@@ -1,7 +1,7 @@
 -- 
--- Obiaway v1.0.2
+-- Obiaway v1.0.3
 -- 
--- Copyright (c) 2013, ReaperX
+-- Copyright ©2013-2014, ReaperX, onetime
 -- All rights reserved.
 -- 
 -- Redistribution and use in source and binary forms, with or without
@@ -27,11 +27,11 @@
 -- (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 -- SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 --
--- Puts elemental obis away when they are no longer needed due
+-- Puts elemental obi away when they are no longer needed due
 -- to day/weather/storm effect change and gets elemental obi based
 -- on same conditions. Uses itemizer addon.
 -- 
--- The advantage of this system compared to moving obis back during 
+-- The advantage of this system compared to moving obi back during 
 -- aftercast is that it avoids excessive inventory movement,
 -- so malfunctions due to inventory filling up completely are
 -- less likely, and timing issues with very fast spells (spell
@@ -40,22 +40,20 @@
 --
 -- Known bugs: 
 --
--- 1. upon activation, it puts only the first unneeded
--- obi away. The function get_needed_obis() tries to put all
+-- 1. Upon activation, it puts only the first unneeded
+-- obi away. The function auto_sort_obi() tries to put all
 -- of them away, but the calls to itemizer are all made instantly
 -- so only the first one is carried out. Usually, only one obi
 -- has to be removed per call, so this is not much of a problem.
 --
--- 2. when weather changes due to zoning, get_obis_in_inventory()
+-- 2. When weather changes due to zoning, get_obi_in_inventory()
 -- is called before inventory has loaded and returns nothing.
 --
 -- 3. Obi is not moved when currently equipped.
--- 
--- To Do: Use a loop to remove and retrieve obi for shorter code
 
 _addon.name = "Obiaway"
-_addon.author = "ReaperX"
-_addon.version = "1.0.2"
+_addon.author = "ReaperX, onetime"
+_addon.version = "1.0.3"
 _addon.commands = {'obi', 'obiaway'}
 
 require('sets')
@@ -64,7 +62,7 @@ config = require('config')
 res = require('resources')
 
 default_settings = {}
-default_settings.notify = 'on'
+default_settings.notify = trues
 default_settings.location = 'sack'
 
 settings = config.load(default_settings)
@@ -77,33 +75,55 @@ end
 windower.register_event('addon command', function()
 
     return function(command, ...)
-        command = command:lower() or 'help'
-        local params = {...}
+        local command = command:lower() or 'help'
+        local params = L{...}:map(string.lower)
 
         if command == 'help' or command == 'h' then
             obi_output("Obiaway v".._addon.version..". Authors: ".._addon.author)
             obi_output("//(obi)away [options]")
             obi_output("   (h)elp :  Displays this help text.")
-            obi_output("   (g)et :  Command for manually getting and removing obis.")
+            obi_output("   (s)ort :  Automatically sorts obi.")
+            obi_output("   (g)et [(a)ll|(n)eeded] :  Gets obi.")
+            obi_output("   (p)ut [(a)ll|(n)eeded] :  Puts obi.")
             obi_output("   (n)otify [on|off] :  Sets obiaway notifcations on or off.")
-            obi_output("   (l)ocation [sack|satchel|case|wardrobe] :  Sets inventory from which to get and put obis.")
+            obi_output("   (l)ocation [sack|satchel|case|wardrobe] :  Sets inventory from which to get and put obi.")
+        elseif command == 'sort' or command == 's' then
+            auto_sort_obi()
+            obi_output("Sorting obi...")
         elseif command == 'get' or command == 'g' then
-            get_needed_obis()
-            obi_output("Sorting obis...")
+            if params[1] == 'all' or params [1] == 'a' then
+                get_all_obi()
+                obi_output('Getting all obi from %s...':format(settings.location))
+            elseif params[1] == 'needed' or params [1] == 'n' then
+                get_needed_obi()
+                obi_output('Getting needed obi from %s...':format(settings.location))
+            else
+                error("Invalid argument. Usage: //obiaway get [all|needed]")
+            end
+        elseif command == 'put' or command == 'p' then
+            if params[1] == 'all' or params [1] == 'a' then
+                put_all_obi()
+                obi_output('Putting all obi into %s...':format(settings.location))
+            elseif params[1] == 'needed' or params [1] == 'n' then
+                put_needed_obi()
+                obi_output('Putting uneeded obi into %s...':format(settings.location))
+            else
+                error("Invalid argument. Usage: //obiaway put [all|needed]")
+            end
         elseif command == 'notify' or command == 'n' then
-            if S{'on'}:contains(params[1]:lower()) then
-                settings.notify = params[1]
+            if params[1] == 'on' then
+                settings.notify = true
                 obi_output("Obiaway notifications are now on")
-            elseif S{'off'}:contains(params[1]:lower()) then
-                settings.notify = params[1]
+            elseif params[1] == 'off' then
+                settings.notify = false
                 obi_output("Obiaway notifications are now off.")
             else
-                error("Invalid argument. Usage: //obiaway [on|off]")
+                error("Invalid argument. Usage: //obiaway notify [on|off]")
             end
         elseif command == 'location' or command == 'l' then
-            if S{'sack','case','satchel','wardrobe'}:contains(params[1]:lower()) then
+            if S{'sack','case','satchel','wardrobe'}:contains(params[1]) then
                 settings.location = params[1]
-                obi_output("Obiaway location set to: "..settings.location)
+                obi_output("Obiaway location set to: %s":format(settings.location))
             else
                 error("Invalid argument. Usage: //obiaway location [sack|satchel|case|wardrobe]")
             end
@@ -113,34 +133,132 @@ windower.register_event('addon command', function()
     end
 end())
 
-function get_obis_in_inventory()
-    obis = {}
-    items = windower.ffxi.get_items()
-    inv = items.inventory
+function get_obi_in_inventory()
+    local obi = {}
+    local items = windower.ffxi.get_items()
+    local inv = items.inventory
     if not inv then return end
-    number = items.max_inventory
+    local number = items.max_inventory
+
     for i=1,number do
         id = inv[i].id
         if ( id>=15435 and id<=15442) then
-            obis["Fire"] = obis["Fire"] or (id == 15435)
-            obis["Ice"] = obis["Ice"] or (id == 15436)
-            obis["Wind"] = obis["Wind"] or (id == 15437)
-            obis["Earth"] = obis["Earth"] or (id == 15438)
-            obis["Lightning"] = obis["Lightning"] or (id == 15439)
-            obis["Water"] = obis["Water"] or (id == 15440)
-            obis["Light"] = obis["Light"] or (id == 15441)
-            obis["Dark"] = obis["Dark"] or (id == 15442)
+            obi["Fire"] = obi["Fire"] or (id == 15435)
+            obi["Ice"] = obi["Ice"] or (id == 15436)
+            obi["Wind"] = obi["Wind"] or (id == 15437)
+            obi["Earth"] = obi["Earth"] or (id == 15438)
+            obi["Lightning"] = obi["Lightning"] or (id == 15439)
+            obi["Water"] = obi["Water"] or (id == 15440)
+            obi["Light"] = obi["Light"] or (id == 15441)
+            obi["Dark"] = obi["Dark"] or (id == 15442)
         end
     end
-    return obis
+
+    return obi
 end
 
-function get_needed_obis()
-    elements = get_all_elements()
-    obis = get_obis_in_inventory()
+function get_needed_obi()
+    local elements = get_all_elements()
+    local obi = get_obi_in_inventory()
+    local str = ''
+    local obi_names = T{
+        Light = 'Korin',
+        Dark = 'Anrin',
+        Fire = 'Karin',
+        Earth = 'Dorin',
+        Water = 'Suirin',
+        Wind = 'Furin',
+        Ice = 'Hyorin',
+        Lightning = 'Rairin'
+    }
+    for name, element in obi_names:it() do
+        if obi[element] and elements[element] > 0 then    
+            str = str..'put "%s Obi" %s;wait .5;':format(name, settings.location)
+            if settings.notify then
+                obi_output('Getting %s Obi from %s.':format(name, settings.location))
+            end
+        end
+    end
+    windower.send_command(str)
+end
+
+function put_unneeded_obi()
+    local elements = get_all_elements()
+    local obi = get_obi_in_inventory()
+    local str = ''
+    local obi_names = T{
+        Light = 'Korin',
+        Dark = 'Anrin',
+        Fire = 'Karin',
+        Earth = 'Dorin',
+        Water = 'Suirin',
+        Wind = 'Furin',
+        Ice = 'Hyorin',
+        Lightning = 'Rairin'
+    }
+    for name, element in obi_names:it() do
+        if obi[element] and elements[element] == 0 then    
+            str = str..'put "%s Obi" %s;wait .5;':format(name, settings.location)
+            if settings.notify then
+                obi_output('Putting %s Obi away into %s.':format(name, settings.location))
+            end
+        end
+    end
+    windower.send_command(str)
+end
+
+function get_all_obi()
+    local elements = get_all_elements()
+    local obi = get_obi_in_inventory()
+    local str = ''
+    local obi_names = T{
+        Light = 'Korin',
+        Dark = 'Anrin',
+        Fire = 'Karin',
+        Earth = 'Dorin',
+        Water = 'Suirin',
+        Wind = 'Furin',
+        Ice = 'Hyorin',
+        Lightning = 'Rairin'
+    }
+    for name, element in obi_names:it() do
+        if not obi[element] then
+            str = str..'get "%s Obi" %s;wait .5;':format(name, settings.location)
+            if settings.notify then
+                obi_output('Getting %s Obi from %s.':format(name, settings.location))
+            end
+        end
+    end
+    windower.send_command(str)
+end
+
+function put_all_obi()
+    local elements = get_all_elements()
+    local obi = get_obi_in_inventory()
+    local str = ''
+    local obi_names = T{
+        Light = 'Korin',
+        Dark = 'Anrin',
+        Fire = 'Karin',
+        Earth = 'Dorin',
+        Water = 'Suirin',
+        Wind = 'Furin',
+        Ice = 'Hyorin',
+        Lightning = 'Rairin'
+    }
+    for name, element in obi_names:it() do
+        if obi[element] then
+            str = str..'put "%s Obi" %s;wait .5;':format(name, settings.location)
+            if settings.notify then
+                obi_output('Putting %s Obi away into %s.':format(name, settings.location))
+            end
+        end
+    end
+    windower.send_command(str)
+end
     
-    areas = {}
-    areas.Cities = S{
+function auto_sort_obi()
+    local cities = S{
         "Ru'Lude Gardens",
         "Upper Jeuno",
         "Lower Jeuno",
@@ -170,156 +288,12 @@ function get_needed_obis()
         "Celennia Memorial Library",
         "Mog Garden"
     }
-    
-    local str = ''
-    if not areas.Cities:contains(res.zones[windower.ffxi.get_info().zone].english) then
-        if obis["Fire"] and elements["Fire"] == 0 then
-            str = str.."put \"Karin Obi\" "..settings.location..";wait .5;"
-            if settings.notify == 'on' then
-                obi_output("Putting Karin Obi away in "..settings.location..".")
-            end
-        end
-        if obis["Earth"] and elements["Earth"] == 0 then
-            str = str.."put \"Dorin Obi\" "..settings.location..";wait .5;"
-            if settings.notify == 'on' then
-                obi_output("Putting Dorin Obi away in "..settings.location..".")
-            end
-        end
-        if obis["Water"] and elements["Water"] == 0 then
-            str = str.."put \"Suirin Obi\" "..settings.location..";wait .5;"
-            if settings.notify == 'on' then
-                obi_output("Putting Suirin Obi away in "..settings.location..".")
-            end
-        end
-        if obis["Wind"] and elements["Wind"] == 0 then
-            str = str.."put \"Furin Obi\" "..settings.location..";wait .5;"
-            if settings.notify == 'on' then
-                obi_output("Putting Furin Obi away in "..settings.location..".")
-            end
-        end
-        if obis["Ice"] and elements["Ice"] == 0 then
-            str = str.."put \"Hyorin Obi\" "..settings.location..";wait .5;"
-            if settings.notify == 'on' then
-                obi_output("Putting Hyorin Obi away in "..settings.location..".")
-            end
-        end
-        if obis["Lightning"] and elements["Lightning"] == 0 then
-            str = str.."put \"Rairin Obi\" "..settings.location..";wait .5;"
-            if settings.notify == 'on' then
-                obi_output("Putting Rairin Obi away in "..settings.location..".")
-            end
-        end
-        if obis["Light"] and elements["Light"] == 0 then    
-            str = str.."put \"Korin Obi\" "..settings.location..";wait .5;"
-            if settings.notify == 'on' then
-                obi_output("Putting Korin Obi away in "..settings.location..".")
-            end
-        end
-        if obis["Dark"] and elements["Dark"] == 0 then    
-            str = str.."put \"Anrin Obi\" "..settings.location..";wait .5;"
-            if settings.notify == 'on' then
-                obi_output("Putting Anrin Obi away in "..settings.location..".")
-            end
-        end
-        if not obis["Fire"] and elements["Fire"] > 0 then
-            str = str.."get \"Karin Obi\" "..settings.location..";wait .5;"
-            if settings.notify == 'on' then
-                obi_output("Getting Karin Obi from "..settings.location..".")
-            end
-        end
-        if not obis["Earth"] and elements["Earth"] > 0 then
-            str = str.."get \"Dorin Obi\" "..settings.location..";wait .5;"
-            if settings.notify == 'on' then
-                obi_output("Getting Dorin Obi from "..settings.location..".")
-            end
-        end
-        if not obis["Water"] and elements["Water"] > 0 then
-            str = str.."get \"Suirin Obi\" "..settings.location..";wait .5;"
-            if settings.notify == 'on' then
-                obi_output("Getting Suirin Obi from "..settings.location..".")
-            end
-        end
-        if not obis["Wind"] and elements["Wind"] > 0 then
-            str = str.."get \"Furin Obi\" "..settings.location..";wait .5;"
-            if settings.notify == 'on' then
-                obi_output("Getting Furin Obi from "..settings.location..".")
-            end
-        end
-        if not obis["Ice"] and elements["Ice"] > 0 then
-            str = str.."get \"Hyorin Obi\" "..settings.location..";wait .5;"
-            if settings.notify == 'on' then
-                obi_output("Getting Hyorin Obi from "..settings.location..".")
-            end
-        end
-        if not obis["Lightning"] and elements["Lightning"] > 0 then
-            str = str.."get \"Rairin Obi\" "..settings.location..";wait .5;"
-            if settings.notify == 'on' then
-                obi_output("Getting Rairin Obi from "..settings.location..".")
-            end
-        end
-        if not obis["Light"] and elements["Light"] > 0 then    
-            str = str.."get \"Korin Obi\" "..settings.location..";wait .5;"
-            if settings.notify == 'on' then
-                obi_output("Getting Korin Obi from "..settings.location..".")
-            end
-        end
-        if not obis["Dark"] and elements["Dark"] > 0 then    
-            str = str.."get \"Anrin Obi\" "..settings.location..";wait .5;"
-            if settings.notify == 'on' then
-                obi_output("Getting Anrin Obi from "..settings.location..".")
-            end
-        end
-        windower.send_command(str)
-    else --in town: put away all obis.
-        if obis["Fire"] then
-            str = str.."put \"Karin Obi\" "..settings.location..";wait .5;"
-            if settings.notify == 'on' then
-                obi_output("Putting Karin Obi away in "..settings.location..".")
-            end
-        end
-        if obis["Earth"] then
-            str = str.."put \"Dorin Obi\" "..settings.location..";wait .5;"
-            if settings.notify == 'on' then
-                obi_output("Putting Dorin Obi away in "..settings.location..".")
-            end
-        end
-        if obis["Water"] then
-            str = str.."put \"Suirin Obi\" "..settings.location..";wait .5;"
-            if settings.notify == 'on' then
-                obi_output("Putting Suirin Obi away in "..settings.location..".")
-            end
-        end
-        if obis["Wind"] then
-            str = str.."put \"Furin Obi\" "..settings.location..";wait .5;"
-            if settings.notify == 'on' then
-                obi_output("Putting Furin Obi away in "..settings.location..".")
-            end
-        end
-        if obis["Ice"] then
-            str = str.."put \"Hyorin Obi\" "..settings.location..";wait .5;"
-            if settings.notify == 'on' then
-                obi_output("Putting Hyorin Obi away in "..settings.location..".")
-            end
-        end
-        if obis["Lightning"] then
-            str = str.."put \"Rairin Obi\" "..settings.location..";wait .5;"
-            if settings.notify == 'on' then
-                obi_output("Putting Rairin Obi away in "..settings.location..".")
-            end
-        end
-        if obis["Light"] then    
-            str = str.."put \"Korin Obi\" "..settings.location..";wait .5;"
-            if settings.notify == 'on' then
-                obi_output("Putting Korin Obi away in "..settings.location..".")
-            end
-        end
-        if obis["Dark"] then    
-            str = str.."put \"Anrin Obi\" "..settings.location..";wait .5;"
-            if settings.notify == 'on' then
-                obi_output("Putting Anrin Obi away in "..settings.location..".")
-            end
-        end
-        windower.send_command(str)
+
+    if not cities:contains(res.zones[windower.ffxi.get_info().zone].english) then
+        put_unneeded_obi()
+        get_needed_obi()
+    else  -- in town. put away all obi.
+        put_all_obi()
     end
 end
 
@@ -332,7 +306,7 @@ end
 
 function get_all_elements()
 
-    elements = {}           
+    local elements = {}           
     elements["Fire"] = 0
     elements["Earth"] = 0
     elements["Water"] = 0
@@ -343,13 +317,13 @@ function get_all_elements()
     elements["Dark"] = 0
     elements["None"] = 0
 
-    info = windower.ffxi.get_info()
+    local info = windower.ffxi.get_info()
 
     local day_element = res.elements[res.days[info.day].element].english
     elements[day_element] = elements[day_element] + 1
     local weather_element = res.elements[res.weather[info.weather].element].english
     elements[weather_element] = elements[weather_element] + 1
-    buffs = windower.ffxi.get_player().buffs
+    local buffs = windower.ffxi.get_player().buffs
 
     if inTable(buffs, 178) then
       elements["Fire"] = elements["Fire"] + 1
@@ -371,6 +345,6 @@ function get_all_elements()
     return elements
 end
 
-windower.register_event('gain buff', get_needed_obis:cond(function(id) return id >= 178 and id <= 185 end))
-windower.register_event('lose buff', get_needed_obis:cond(function(id) return id >= 178 and id <= 185 end))
-windower.register_event('day change', 'weather change', get_needed_obis)
+windower.register_event('gain buff', auto_sort_obi:cond(function(id) return id >= 178 and id <= 185 end))
+windower.register_event('lose buff', auto_sort_obi:cond(function(id) return id >= 178 and id <= 185 end))
+windower.register_event('day change', 'weather change', auto_sort_obi)

--- a/addons/obiaway/Obiaway.lua
+++ b/addons/obiaway/Obiaway.lua
@@ -54,7 +54,7 @@
 -- To Do: Use a loop to remove and retrieve obi for shorter code
 
 _addon.name = "Obiaway"
-_addon.author = "ReaperX, onetime"
+_addon.author = "ReaperX"
 _addon.version = "1.0.2"
 _addon.commands = {'obi', 'obiaway'}
 

--- a/addons/obiaway/Obiaway.lua
+++ b/addons/obiaway/Obiaway.lua
@@ -1,5 +1,5 @@
 -- 
--- Obiaway v1.0.6
+-- Obiaway v1.0.7
 -- 
 -- Copyright ©2013-2014, ReaperX, onetime
 -- All rights reserved.
@@ -206,14 +206,11 @@ function inventory_full(command, location)
     local items = windower.ffxi.get_items(id)
     if free_space(location) == 0 then
         if command then
-            print('fiskity fuck')
             obi_output('%s is full.':format(string.ucfirst(location)))
         elseif not tokens.inv_full_warned and id == 0 then
-            print('fuskity fook')
             tokens.inv_full_warned = true
             obi_output('%s is full.':format(string.ucfirst(location)))
         elseif not tokens.bag_full_warned then
-            print('frickity frack')
             tokens.bag_full_warned = true
             obi_output('%s is full.':format(string.ucfirst(location)))
         end

--- a/addons/obiaway/Obiaway.lua
+++ b/addons/obiaway/Obiaway.lua
@@ -93,20 +93,20 @@ windower.register_event('addon command', function()
         elseif command == 'get' or command == 'g' then
             if params[1] == 'all' or params [1] == 'a' then
                 obi_output('Getting all obi from %s...':format(settings.location))
-                get_all_obi()
+                get_all_obi(true)
             elseif params[1] == 'needed' or params [1] == 'n' then
                 obi_output('Getting needed obi from %s...':format(settings.location))
-                get_needed_obi()
+                get_needed_obi(true)
             else
                 error("Invalid argument. Usage: //obiaway get [ all | needed ]")
             end
         elseif command == 'put' or command == 'p' then
             if params[1] == 'all' or params [1] == 'a' then
                 obi_output('Putting all obi into %s...':format(settings.location))
-                put_all_obi()
+                put_all_obi(true)
             elseif params[1] == 'unneeded' or params[1] == 'needed' or params [1] == 'n' then
                 obi_output('Putting unneeded obi into %s...':format(settings.location))
-                put_unneeded_obi()
+                put_unneeded_obi(true)
             else
                 error("Invalid argument. Usage: //obiaway put [ all | needed ]")
             end
@@ -157,7 +157,7 @@ function get_obi_in_inventory()
     return obi
 end
 
-function get_needed_obi()
+function get_needed_obi(command)
     local elements = get_all_elements()
     local obi = get_obi_in_inventory()
     local str = ''
@@ -172,17 +172,21 @@ function get_needed_obi()
         Lightning = 'Rairin'
     }
     for name, element in obi_names:it() do
-        if obi[element] and elements[element] > 0 then    
-            str = str..'put "%s Obi" %s;wait .5;':format(name, settings.location)
+        if not obi[element] and elements[element] > 0 then
+            str = str..'get "%s Obi" %s;wait .5;':format(name, settings.location)
             if settings.notify then
                 obi_output('Getting %s Obi from %s.':format(name, settings.location))
             end
         end
     end
-    windower.send_command(str)
+    if command then
+        windower.send_command(str)
+    else
+        return str
+    end
 end
 
-function put_unneeded_obi()
+function put_unneeded_obi(command)
     local elements = get_all_elements()
     local obi = get_obi_in_inventory()
     local str = ''
@@ -196,6 +200,7 @@ function put_unneeded_obi()
         Ice = 'Hyorin',
         Lightning = 'Rairin'
     }
+
     for name, element in obi_names:it() do
         if obi[element] and elements[element] == 0 then    
             str = str..'put "%s Obi" %s;wait .5;':format(name, settings.location)
@@ -204,10 +209,14 @@ function put_unneeded_obi()
             end
         end
     end
-    windower.send_command(str)
+    if command then
+        windower.send_command(str)
+    else
+        return str
+    end
 end
 
-function get_all_obi()
+function get_all_obi(command)
     local elements = get_all_elements()
     local obi = get_obi_in_inventory()
     local str = ''
@@ -229,10 +238,14 @@ function get_all_obi()
             end
         end
     end
-    windower.send_command(str)
+    if command then
+        windower.send_command(str)
+    else
+        return str
+    end
 end
 
-function put_all_obi()
+function put_all_obi(command)
     local elements = get_all_elements()
     local obi = get_obi_in_inventory()
     local str = ''
@@ -254,7 +267,11 @@ function put_all_obi()
             end
         end
     end
-    windower.send_command(str)
+    if command then
+        windower.send_command(str)
+    else
+        return str
+    end
 end
     
 function auto_sort_obi()
@@ -288,12 +305,14 @@ function auto_sort_obi()
         "Celennia Memorial Library",
         "Mog Garden"
     }
-
+    local str = ''
     if not cities:contains(res.zones[windower.ffxi.get_info().zone].english) then
-        put_unneeded_obi()
-        get_needed_obi()
+        str = str..put_unneeded_obi(false)
+        str = str..get_needed_obi(false)
+        windower.send_command(str)
     else  -- in town. put away all obi.
-        put_all_obi()
+        str = str..put_all_obi(false)
+        windower.send_command(str)
     end
 end
 

--- a/addons/obiaway/Obiaway.lua
+++ b/addons/obiaway/Obiaway.lua
@@ -62,7 +62,7 @@ config = require('config')
 res = require('resources')
 
 default_settings = {}
-default_settings.notify = trues
+default_settings.notify = true
 default_settings.location = 'sack'
 
 settings = config.load(default_settings)

--- a/addons/obiaway/Obiaway.lua
+++ b/addons/obiaway/Obiaway.lua
@@ -206,14 +206,11 @@ function inventory_full(command, location)
     local items = windower.ffxi.get_items(id)
     if free_space(location) == 0 then
         if command then
-            print('fiskity fuck')
             obi_output('%s is full.':format(string.ucfirst(location)))
         elseif not tokens.inv_full_warned and id == 0 then
-            print('fuskity fook')
             tokens.inv_full_warned = true
             obi_output('%s is full.':format(string.ucfirst(location)))
         elseif not tokens.bag_full_warned then
-            print('frickity frack')
             tokens.bag_full_warned = true
             obi_output('%s is full.':format(string.ucfirst(location)))
         end

--- a/addons/obiaway/Obiaway.lua
+++ b/addons/obiaway/Obiaway.lua
@@ -301,41 +301,43 @@ end
 -- function designer: ReaperX
 function get_all_elements()
     local elements = {}           
-    elements["Fire"] = false
-    elements["Earth"] = false
-    elements["Water"] = false
-    elements["Wind"] = false
-    elements["Ice"] = false
-    elements["Lightning"] = false
-    elements["Light"] = false
-    elements["Dark"] = false
-    elements["None"] = false
+    elements["Fire"] = 0
+    elements["Earth"] = 0
+    elements["Water"] = 0
+    elements["Wind"] = 0
+    elements["Ice"] = 0
+    elements["Lightning"] = 0
+    elements["Light"] = 0
+    elements["Dark"] = 0
+    elements["None"] = 0
 
+	-- check for active Day and Weather
     local info = windower.ffxi.get_info()
-
     local day_element = res.elements[res.days[info.day].element].english
     elements[day_element] = elements[day_element] + 1
     local weather_element = res.elements[res.weather[info.weather].element].english
     elements[weather_element] = elements[weather_element] + 1
+	
+	-- check for active SCH buffs
     local buffs = windower.ffxi.get_player().buffs
-
     if inTable(buffs, 178) then
-      elements["Fire"] = true
+      elements["Fire"] =  elements["Fire"] + 1
     elseif inTable(buffs, 183) then
-      elements["Water"] = true
+      elements["Water"] = elements["Water"] + 1
     elseif inTable(buffs, 181) then
-      elements["Earth"] = true
+      elements["Earth"] = elements["Earth"] + 1
     elseif inTable(buffs, 180) then
-      elements["Wind"] = true
+      elements["Wind"] = elements["Wind"] +1
     elseif inTable(buffs, 179) then
-      elements["Ice"] = true
+      elements["Ice"] = elements["Ice"] + 1
     elseif inTable(buffs, 182) then
-      elements["Lightning"] = true
+      elements["Lightning"] = elements["Lightning"] + 1
     elseif inTable(buffs, 184) then
-      elements["Light"] = true
+      elements["Light"] = elements["Light"] + 1
     elseif inTable(buffs, 185) then
-      elements["Dark"] = true
+      elements["Dark"] = elements["Dark"] + 1
     end
+	
     return elements
 end
 
@@ -349,7 +351,7 @@ function get_needed_obi(command)
     local elements = get_all_elements()
 
     for name, element in obi_names:it() do
-        if not obi[element] and elements[element] then
+        if not obi[element] and elements[element] > 0 then
             windower.send_command('get "%s Obi" %s;':format(name, settings.location))
             if settings.notify then
                 obi_output('Getting %s Obi from %s.':format(name, settings.location))
@@ -367,7 +369,7 @@ function put_unneeded_obi(command)
     local elements = get_all_elements()
 
     for name, element in obi_names:it() do
-        if obi[element] and not elements[element] then    
+        if obi[element] and elements[element] == 0 then    
             windower.send_command('put "%s Obi" %s;':format(name, settings.location))
             if settings.notify then
                 obi_output('Putting %s Obi away into %s.':format(name, settings.location))

--- a/addons/obiaway/Obiaway.lua
+++ b/addons/obiaway/Obiaway.lua
@@ -69,50 +69,50 @@ settings = config.load(default_settings)
 
 -- Accepts msg as a string or a table
 function obi_output(msg)
-	windower.add_to_chat(209, msg)
+    windower.add_to_chat(209, msg)
 end
 
 windower.register_event('addon command', function()
 
-	return function(command, ...)
-		command = command:lower() or 'help'
+    return function(command, ...)
+        command = command:lower() or 'help'
         local params = {...}
 
-		if command == 'help' or command == 'h' then
-			obi_output("Obiaway v".._addon.version..". Authors: ".._addon.author)
-			obi_output("//(obi)away [options]")
-			obi_output("   (h)elp :  Displays this help text.")
-			obi_output("   (g)et :  Command for manually getting and removing obis.")
-			obi_output("   (n)otify [on|off] :  Sets obiaway notifcations on or off.")
-			obi_output("   (l)ocation [sack|satchel|case|wardrobe] :  Sets inventory from which to get and put obis.")
-		elseif command == 'get' or command == 'g' then
-			get_needed_obis()
-			obi_output("Sorting obis...")
-		elseif command == 'notify' or command == 'n' then
-			if S{'on'}:contains(params[1]:lower()) then
-				settings.notify = params[1]
-				obi_output("Obiaway notifications are now on")
+        if command == 'help' or command == 'h' then
+            obi_output("Obiaway v".._addon.version..". Authors: ".._addon.author)
+            obi_output("//(obi)away [options]")
+            obi_output("   (h)elp :  Displays this help text.")
+            obi_output("   (g)et :  Command for manually getting and removing obis.")
+            obi_output("   (n)otify [on|off] :  Sets obiaway notifcations on or off.")
+            obi_output("   (l)ocation [sack|satchel|case|wardrobe] :  Sets inventory from which to get and put obis.")
+        elseif command == 'get' or command == 'g' then
+            get_needed_obis()
+            obi_output("Sorting obis...")
+        elseif command == 'notify' or command == 'n' then
+            if S{'on'}:contains(params[1]:lower()) then
+                settings.notify = params[1]
+                obi_output("Obiaway notifications are now on")
 			elseif S{'off'}:contains(params[1]:lower()) then
-				settings.notify = params[1]
-				obi_output("Obiaway notifications are now off.")
-			else
-				error("Invalid argument. Usage: //obiaway [on|off]")
-			end
-		elseif command == 'location' or command == 'l' then
-			if S{'sack','case','satchel','wardrobe'}:contains(params[1]:lower()) then
-				settings.location = params[1]
-				obi_output("Obiaway location set to: "..settings.location)
-			else
-				error("Invalid argument. Usage: //obiaway location [sack|satchel|case|wardrobe]")
-			end
-		else
-			error("Unrecognized command. See //obiaway help.")
-		end
-	end
+                settings.notify = params[1]
+                obi_output("Obiaway notifications are now off.")
+            else
+                error("Invalid argument. Usage: //obiaway [on|off]")
+            end
+        elseif command == 'location' or command == 'l' then
+            if S{'sack','case','satchel','wardrobe'}:contains(params[1]:lower()) then
+                settings.location = params[1]
+                obi_output("Obiaway location set to: "..settings.location)
+            else
+                error("Invalid argument. Usage: //obiaway location [sack|satchel|case|wardrobe]")
+            end
+        else
+            error("Unrecognized command. See //obiaway help.")
+        end
+    end
 end())
 
 function get_obis_in_inventory()
-	obis = {}
+    obis = {}
     items = windower.ffxi.get_items()
     inv = items.inventory
     if not inv then return end
@@ -139,38 +139,38 @@ function get_needed_obis()
 	
     areas = {}
     areas.Cities = S{
-	"Ru'Lude Gardens",
-	"Upper Jeuno",
-	"Lower Jeuno",
-	"Port Jeuno",
-	"Port Windurst",
-	"Windurst Waters",
-	"Windurst Woods",
-	"Windurst Walls",
-	"Heavens Tower",
-	"Port San d'Oria",
-	"Northern San d'Oria",
-	"Southern San d'Oria",
-	"Port Bastok",
-	"Bastok Markets",
-	"Bastok Mines",
-	"Metalworks",
-	"Aht Urhgan Whitegate",
-	"Tavanazian Safehold",
-	"Nashmau",
-	"Selbina",
-	"Mhaura",
-	"Norg",
-	"Kazham",
-	"Eastern Adoulin",
-	"Western Adoulin",
-	"Leafallia",
-	"Celennia Memorial Library",
-	"Mog Garden"
+        "Ru'Lude Gardens",
+        "Upper Jeuno",
+        "Lower Jeuno",
+        "Port Jeuno",
+        "Port Windurst",
+        "Windurst Waters",
+        "Windurst Woods",
+        "Windurst Walls",
+        "Heavens Tower",
+        "Port San d'Oria",
+        "Northern San d'Oria",
+        "Southern San d'Oria",
+        "Port Bastok",
+        "Bastok Markets",
+        "Bastok Mines",
+        "Metalworks",
+        "Aht Urhgan Whitegate",
+        "Tavanazian Safehold",
+        "Nashmau",
+        "Selbina",
+        "Mhaura",
+        "Norg",
+        "Kazham",
+        "Eastern Adoulin",
+        "Western Adoulin",
+        "Leafallia",
+        "Celennia Memorial Library",
+        "Mog Garden"
 	}
 	
     local str = ''
-	if not areas.Cities:contains(res.zones[windower.ffxi.get_info().zone].english) then
+    if not areas.Cities:contains(res.zones[windower.ffxi.get_info().zone].english) then
 		if obis["Fire"] and elements["Fire"] == 0 then
 			str = str.."put \"Karin Obi\" "..settings.location..";wait .5;"
 			if settings.notify == 'on' then

--- a/addons/obiaway/Obiaway.lua
+++ b/addons/obiaway/Obiaway.lua
@@ -92,7 +92,7 @@ windower.register_event('addon command', function()
             if S{'on'}:contains(params[1]:lower()) then
                 settings.notify = params[1]
                 obi_output("Obiaway notifications are now on")
-			elseif S{'off'}:contains(params[1]:lower()) then
+            elseif S{'off'}:contains(params[1]:lower()) then
                 settings.notify = params[1]
                 obi_output("Obiaway notifications are now off.")
             else
@@ -136,7 +136,7 @@ end
 function get_needed_obis()
     elements = get_all_elements()
     obis = get_obis_in_inventory()
-	
+    
     areas = {}
     areas.Cities = S{
         "Ru'Lude Gardens",
@@ -167,158 +167,158 @@ function get_needed_obis()
         "Leafallia",
         "Celennia Memorial Library",
         "Mog Garden"
-	}
-	
+    }
+    
     local str = ''
     if not areas.Cities:contains(res.zones[windower.ffxi.get_info().zone].english) then
-		if obis["Fire"] and elements["Fire"] == 0 then
-			str = str.."put \"Karin Obi\" "..settings.location..";wait .5;"
-			if settings.notify == 'on' then
-				obi_output("Putting Karin Obi away in "..settings.location..".")
-			end
-		end
-		if obis["Earth"] and elements["Earth"] == 0 then
-			str = str.."put \"Dorin Obi\" "..settings.location..";wait .5;"
-			if settings.notify == 'on' then
-				obi_output("Putting Dorin Obi away in "..settings.location..".")
-			end
-		end
-		if obis["Water"] and elements["Water"] == 0 then
-			str = str.."put \"Suirin Obi\" "..settings.location..";wait .5;"
-			if settings.notify == 'on' then
-				obi_output("Putting Suirin Obi away in "..settings.location..".")
-			end
-		end
-		if obis["Wind"] and elements["Wind"] == 0 then
-			str = str.."put \"Furin Obi\" "..settings.location..";wait .5;"
-			if settings.notify == 'on' then
-				obi_output("Putting Furin Obi away in "..settings.location..".")
-			end
-		end
-		if obis["Ice"] and elements["Ice"] == 0 then
-			str = str.."put \"Hyorin Obi\" "..settings.location..";wait .5;"
-			if settings.notify == 'on' then
-				obi_output("Putting Hyorin Obi away in "..settings.location..".")
-			end
-		end
-		if obis["Lightning"] and elements["Lightning"] == 0 then
-			str = str.."put \"Rairin Obi\" "..settings.location..";wait .5;"
-			if settings.notify == 'on' then
-				obi_output("Putting Rairin Obi away in "..settings.location..".")
-			end
-		end
-		if obis["Light"] and elements["Light"] == 0 then    
-			str = str.."put \"Korin Obi\" "..settings.location..";wait .5;"
-			if settings.notify == 'on' then
-				obi_output("Putting Korin Obi away in "..settings.location..".")
-			end
-		end
-		if obis["Dark"] and elements["Dark"] == 0 then    
-			str = str.."put \"Anrin Obi\" "..settings.location..";wait .5;"
-			if settings.notify == 'on' then
-				obi_output("Putting Anrin Obi away in "..settings.location..".")
-			end
-		end
-		if not obis["Fire"] and elements["Fire"] > 0 then
-			str = str.."get \"Karin Obi\" "..settings.location..";wait .5;"
-			if settings.notify == 'on' then
-				obi_output("Getting Karin Obi from "..settings.location..".")
-			end
-		end
-		if not obis["Earth"] and elements["Earth"] > 0 then
-			str = str.."get \"Dorin Obi\" "..settings.location..";wait .5;"
-			if settings.notify == 'on' then
-				obi_output("Getting Dorin Obi from "..settings.location..".")
-			end
-		end
-		if not obis["Water"] and elements["Water"] > 0 then
-			str = str.."get \"Suirin Obi\" "..settings.location..";wait .5;"
-			if settings.notify == 'on' then
-				obi_output("Getting Suirin Obi from "..settings.location..".")
-			end
-		end
-		if not obis["Wind"] and elements["Wind"] > 0 then
-			str = str.."get \"Furin Obi\" "..settings.location..";wait .5;"
-			if settings.notify == 'on' then
-				obi_output("Getting Furin Obi from "..settings.location..".")
-			end
-		end
-		if not obis["Ice"] and elements["Ice"] > 0 then
-			str = str.."get \"Hyorin Obi\" "..settings.location..";wait .5;"
-			if settings.notify == 'on' then
-				obi_output("Getting Hyorin Obi from "..settings.location..".")
-			end
-		end
-		if not obis["Lightning"] and elements["Lightning"] > 0 then
-			str = str.."get \"Rairin Obi\" "..settings.location..";wait .5;"
-			if settings.notify == 'on' then
-				obi_output("Getting Rairin Obi from "..settings.location..".")
-			end
-		end
-		if not obis["Light"] and elements["Light"] > 0 then    
-			str = str.."get \"Korin Obi\" "..settings.location..";wait .5;"
-			if settings.notify == 'on' then
-				obi_output("Getting Korin Obi from "..settings.location..".")
-			end
-		end
-		if not obis["Dark"] and elements["Dark"] > 0 then    
-			str = str.."get \"Anrin Obi\" "..settings.location..";wait .5;"
-			if settings.notify == 'on' then
-				obi_output("Getting Anrin Obi from "..settings.location..".")
-			end
-		end
-		windower.send_command(str)
-	else --in town: put away all obis.
-		if obis["Fire"] then
-			str = str.."put \"Karin Obi\" "..settings.location..";wait .5;"
-			if settings.notify == 'on' then
-				obi_output("Putting Karin Obi away in "..settings.location..".")
-			end
-		end
-		if obis["Earth"] then
-			str = str.."put \"Dorin Obi\" "..settings.location..";wait .5;"
-			if settings.notify == 'on' then
-				obi_output("Putting Dorin Obi away in "..settings.location..".")
-			end
-		end
-		if obis["Water"] then
-			str = str.."put \"Suirin Obi\" "..settings.location..";wait .5;"
-			if settings.notify == 'on' then
-				obi_output("Putting Suirin Obi away in "..settings.location..".")
-			end
-		end
-		if obis["Wind"] then
-			str = str.."put \"Furin Obi\" "..settings.location..";wait .5;"
-			if settings.notify == 'on' then
-				obi_output("Putting Furin Obi away in "..settings.location..".")
-			end
-		end
-		if obis["Ice"] then
-			str = str.."put \"Hyorin Obi\" "..settings.location..";wait .5;"
-			if settings.notify == 'on' then
-				obi_output("Putting Hyorin Obi away in "..settings.location..".")
-			end
-		end
-		if obis["Lightning"] then
-			str = str.."put \"Rairin Obi\" "..settings.location..";wait .5;"
-			if settings.notify == 'on' then
-				obi_output("Putting Rairin Obi away in "..settings.location..".")
-			end
-		end
-		if obis["Light"] then    
-			str = str.."put \"Korin Obi\" "..settings.location..";wait .5;"
-			if settings.notify == 'on' then
-				obi_output("Putting Korin Obi away in "..settings.location..".")
-			end
-		end
-		if obis["Dark"] then    
-			str = str.."put \"Anrin Obi\" "..settings.location..";wait .5;"
-			if settings.notify == 'on' then
-				obi_output("Putting Anrin Obi away in "..settings.location..".")
-			end
-		end
-		windower.send_command(str)
-	end
+        if obis["Fire"] and elements["Fire"] == 0 then
+            str = str.."put \"Karin Obi\" "..settings.location..";wait .5;"
+            if settings.notify == 'on' then
+                obi_output("Putting Karin Obi away in "..settings.location..".")
+            end
+        end
+        if obis["Earth"] and elements["Earth"] == 0 then
+            str = str.."put \"Dorin Obi\" "..settings.location..";wait .5;"
+            if settings.notify == 'on' then
+                obi_output("Putting Dorin Obi away in "..settings.location..".")
+            end
+        end
+        if obis["Water"] and elements["Water"] == 0 then
+            str = str.."put \"Suirin Obi\" "..settings.location..";wait .5;"
+            if settings.notify == 'on' then
+                obi_output("Putting Suirin Obi away in "..settings.location..".")
+            end
+        end
+        if obis["Wind"] and elements["Wind"] == 0 then
+            str = str.."put \"Furin Obi\" "..settings.location..";wait .5;"
+            if settings.notify == 'on' then
+                obi_output("Putting Furin Obi away in "..settings.location..".")
+            end
+        end
+        if obis["Ice"] and elements["Ice"] == 0 then
+            str = str.."put \"Hyorin Obi\" "..settings.location..";wait .5;"
+            if settings.notify == 'on' then
+                obi_output("Putting Hyorin Obi away in "..settings.location..".")
+            end
+        end
+        if obis["Lightning"] and elements["Lightning"] == 0 then
+            str = str.."put \"Rairin Obi\" "..settings.location..";wait .5;"
+            if settings.notify == 'on' then
+                obi_output("Putting Rairin Obi away in "..settings.location..".")
+            end
+        end
+        if obis["Light"] and elements["Light"] == 0 then    
+            str = str.."put \"Korin Obi\" "..settings.location..";wait .5;"
+            if settings.notify == 'on' then
+                obi_output("Putting Korin Obi away in "..settings.location..".")
+            end
+        end
+        if obis["Dark"] and elements["Dark"] == 0 then    
+            str = str.."put \"Anrin Obi\" "..settings.location..";wait .5;"
+            if settings.notify == 'on' then
+                obi_output("Putting Anrin Obi away in "..settings.location..".")
+            end
+        end
+        if not obis["Fire"] and elements["Fire"] > 0 then
+            str = str.."get \"Karin Obi\" "..settings.location..";wait .5;"
+            if settings.notify == 'on' then
+                obi_output("Getting Karin Obi from "..settings.location..".")
+            end
+        end
+        if not obis["Earth"] and elements["Earth"] > 0 then
+            str = str.."get \"Dorin Obi\" "..settings.location..";wait .5;"
+            if settings.notify == 'on' then
+                obi_output("Getting Dorin Obi from "..settings.location..".")
+            end
+        end
+        if not obis["Water"] and elements["Water"] > 0 then
+            str = str.."get \"Suirin Obi\" "..settings.location..";wait .5;"
+            if settings.notify == 'on' then
+                obi_output("Getting Suirin Obi from "..settings.location..".")
+            end
+        end
+        if not obis["Wind"] and elements["Wind"] > 0 then
+            str = str.."get \"Furin Obi\" "..settings.location..";wait .5;"
+            if settings.notify == 'on' then
+                obi_output("Getting Furin Obi from "..settings.location..".")
+            end
+        end
+        if not obis["Ice"] and elements["Ice"] > 0 then
+            str = str.."get \"Hyorin Obi\" "..settings.location..";wait .5;"
+            if settings.notify == 'on' then
+                obi_output("Getting Hyorin Obi from "..settings.location..".")
+            end
+        end
+        if not obis["Lightning"] and elements["Lightning"] > 0 then
+            str = str.."get \"Rairin Obi\" "..settings.location..";wait .5;"
+            if settings.notify == 'on' then
+                obi_output("Getting Rairin Obi from "..settings.location..".")
+            end
+        end
+        if not obis["Light"] and elements["Light"] > 0 then    
+            str = str.."get \"Korin Obi\" "..settings.location..";wait .5;"
+            if settings.notify == 'on' then
+                obi_output("Getting Korin Obi from "..settings.location..".")
+            end
+        end
+        if not obis["Dark"] and elements["Dark"] > 0 then    
+            str = str.."get \"Anrin Obi\" "..settings.location..";wait .5;"
+            if settings.notify == 'on' then
+                obi_output("Getting Anrin Obi from "..settings.location..".")
+            end
+        end
+        windower.send_command(str)
+    else --in town: put away all obis.
+        if obis["Fire"] then
+            str = str.."put \"Karin Obi\" "..settings.location..";wait .5;"
+            if settings.notify == 'on' then
+                obi_output("Putting Karin Obi away in "..settings.location..".")
+            end
+        end
+        if obis["Earth"] then
+            str = str.."put \"Dorin Obi\" "..settings.location..";wait .5;"
+            if settings.notify == 'on' then
+                obi_output("Putting Dorin Obi away in "..settings.location..".")
+            end
+        end
+        if obis["Water"] then
+            str = str.."put \"Suirin Obi\" "..settings.location..";wait .5;"
+            if settings.notify == 'on' then
+                obi_output("Putting Suirin Obi away in "..settings.location..".")
+            end
+        end
+        if obis["Wind"] then
+            str = str.."put \"Furin Obi\" "..settings.location..";wait .5;"
+            if settings.notify == 'on' then
+                obi_output("Putting Furin Obi away in "..settings.location..".")
+            end
+        end
+        if obis["Ice"] then
+            str = str.."put \"Hyorin Obi\" "..settings.location..";wait .5;"
+            if settings.notify == 'on' then
+                obi_output("Putting Hyorin Obi away in "..settings.location..".")
+            end
+        end
+        if obis["Lightning"] then
+            str = str.."put \"Rairin Obi\" "..settings.location..";wait .5;"
+            if settings.notify == 'on' then
+                obi_output("Putting Rairin Obi away in "..settings.location..".")
+            end
+        end
+        if obis["Light"] then    
+            str = str.."put \"Korin Obi\" "..settings.location..";wait .5;"
+            if settings.notify == 'on' then
+                obi_output("Putting Korin Obi away in "..settings.location..".")
+            end
+        end
+        if obis["Dark"] then    
+            str = str.."put \"Anrin Obi\" "..settings.location..";wait .5;"
+            if settings.notify == 'on' then
+                obi_output("Putting Anrin Obi away in "..settings.location..".")
+            end
+        end
+        windower.send_command(str)
+    end
 end
 
 function inTable(tbl, item)

--- a/addons/obiaway/Obiaway.lua
+++ b/addons/obiaway/Obiaway.lua
@@ -1,5 +1,5 @@
 -- 
--- Obiaway v1.0.6
+-- Obiaway v1.0.7
 -- 
 -- Copyright ©2013-2014, ReaperX, onetime
 -- All rights reserved.

--- a/addons/obiaway/Obiaway.lua
+++ b/addons/obiaway/Obiaway.lua
@@ -1,7 +1,7 @@
 -- 
 -- Obiaway v1.0.7
 -- 
--- Copyright ©2013-2014, ReaperX, onetime
+-- Copyright ©2013-2015, ReaperX, bangerang
 -- All rights reserved.
 -- 
 -- Redistribution and use in source and binary forms, with or without
@@ -58,8 +58,8 @@
 
 -- addon info
 _addon.name = "Obiaway"
-_addon.author = "ReaperX, onetime"
-_addon.version = "1.0.7"
+_addon.author = "ReaperX, bangerang"
+_addon.version = "1.0.6"
 _addon.commands = {'oa', 'ob', 'obi', 'obiaway'}
 _addon.language = 'english'
 
@@ -75,6 +75,11 @@ default_settings.notify = true
 default_settings.location = 'sack'
 default_settings.lock = false
 default_settings.color = 209
+default_settings.ignoreZones = S{
+    "Ru'Lude Gardens", "Upper Jeuno", "Lower Jeuno", "Port Jeuno", "Port Windurst", "Windurst Waters", "Windurst Woods", "Windurst Walls",
+    "Heavens Tower", "Port San d'Oria", "Northern San d'Oria", "Southern San d'Oria", "Chateau d'Oraguille", "Port Bastok", "Bastok Markets",
+    "Bastok Mines", "Metalworks", "Aht Urhgan Whitegate", "Tavnazian Safehold", "Nashmau", "Selbina", "Mhaura", "Norg", "Rabao", "Kazham",
+    "Eastern Adoulin", "Western Adoulin", "Leafallia", "Celennia Memorial Library", "Mog Garden"}
 settings = config.load(default_settings)
 
 -- tokens
@@ -84,37 +89,6 @@ tokens.inv_full_warned = false
 tokens.bag_full_warned = false
 
 -- lists
-obi_cities = S{
-    "Ru'Lude Gardens",
-    "Upper Jeuno",
-    "Lower Jeuno",
-    "Port Jeuno",
-    "Port Windurst",
-    "Windurst Waters",
-    "Windurst Woods",
-    "Windurst Walls",
-    "Heavens Tower",
-    "Port San d'Oria",
-    "Northern San d'Oria",
-    "Southern San d'Oria",
-    "Port Bastok",
-    "Bastok Markets",
-    "Bastok Mines",
-    "Metalworks",
-    "Aht Urhgan Whitegate",
-    "Tavnazian Safehold",
-    "Nashmau",
-    "Selbina",
-    "Mhaura",
-    "Norg",
-    "Kazham",
-    "Eastern Adoulin",
-    "Western Adoulin",
-    "Leafallia",
-    "Celennia Memorial Library",
-    "Mog Garden"
-}
-
 obi_names = T{
     Light = 'Korin',
     Dark = 'Anrin',
@@ -435,10 +409,10 @@ function auto_sort_obi()
     if inventory_full(false) and inventory_full(false, settings.location) then return false end
 
     if not settings.lock then -- if sorting lock is not on, then do this stuff:
-        if not obi_cities:contains(res.zones[windower.ffxi.get_info().zone].english) then -- In a city:
+        if not settings.ignoreZones:contains(res.zones[windower.ffxi.get_info().zone].english) then -- Not in a city:
             put_unneeded_obi(false)
             get_needed_obi(false)
-        else-- Not in a city:
+        else -- In a city:
             put_all_obi(false)
         end
     end

--- a/addons/obiaway/Obiaway.lua
+++ b/addons/obiaway/Obiaway.lua
@@ -59,7 +59,7 @@
 -- addon info
 _addon.name = "Obiaway"
 _addon.author = "ReaperX, bangerang"
-_addon.version = "1.0.6"
+_addon.version = "1.0.7"
 _addon.commands = {'oa', 'ob', 'obi', 'obiaway'}
 _addon.language = 'english'
 
@@ -75,7 +75,7 @@ default_settings.notify = true
 default_settings.location = 'sack'
 default_settings.lock = false
 default_settings.color = 209
-default_settings.ignoreZones = S{
+default_settings.ignorezones = S{
     "Ru'Lude Gardens", "Upper Jeuno", "Lower Jeuno", "Port Jeuno", "Port Windurst", "Windurst Waters", "Windurst Woods", "Windurst Walls",
     "Heavens Tower", "Port San d'Oria", "Northern San d'Oria", "Southern San d'Oria", "Chateau d'Oraguille", "Port Bastok", "Bastok Markets",
     "Bastok Mines", "Metalworks", "Aht Urhgan Whitegate", "Tavnazian Safehold", "Nashmau", "Selbina", "Mhaura", "Norg", "Rabao", "Kazham",
@@ -113,16 +113,7 @@ end
 
 -- Accepts a boolean value and returns an appropriate string value. i.e. true -> 'on'
 function booltostr(bool)
-    local str = ''
-    if bool then
-        str = 'on'
-        return str
-    elseif not bool then
-        str = 'off'
-        return str
-    else
-        print('Boolean to string: unknown error.')
-    end
+    return bool and 'on' or 'off'
 end
 
 -- checks if a value is in a table and then returns its key. Ex: a table contains Key = Value. returns Key. returns false if no match.
@@ -152,9 +143,9 @@ function inv_str_to_id(str)
         return 7
     elseif str == 'wardrobe' then
         return 8
-	else
-		print('Obiaway: Function inv_str_to_id invalid argument')
-		return
+    else
+        print('Obiaway: Function inv_str_to_id invalid argument')
+        return
     end
 end
 
@@ -174,7 +165,7 @@ end
 function inventory_full(command, location)
     local id = inv_str_to_id(location)
     if id == 0 then location = 'inventory' end
-	
+    
     if free_space(location) == 0 then
         if command then
             obi_output('%s is full.':format(string.ucfirst(location)))
@@ -285,14 +276,14 @@ function get_all_elements()
     elements["Dark"] = 0
     elements["None"] = 0
 
-	-- check for active Day and Weather
+    -- check for active Day and Weather
     local info = windower.ffxi.get_info()
     local day_element = res.elements[res.days[info.day].element].english
     elements[day_element] = elements[day_element] + 1
     local weather_element = res.elements[res.weather[info.weather].element].english
     elements[weather_element] = elements[weather_element] + 1
-	
-	-- check for active SCH buffs
+    
+    -- check for active SCH buffs
     local buffs = windower.ffxi.get_player().buffs
     if inTable(buffs, 178) then
       elements["Fire"] =  elements["Fire"] + 1
@@ -311,7 +302,7 @@ function get_all_elements()
     elseif inTable(buffs, 185) then
       elements["Dark"] = elements["Dark"] + 1
     end
-	
+    
     return elements
 end
 
@@ -409,15 +400,15 @@ function auto_sort_obi()
     if inventory_full(false) and inventory_full(false, settings.location) then return false end
 
     if not settings.lock then -- if sorting lock is not on, then do this stuff:
-        if not settings.ignoreZones:contains(res.zones[windower.ffxi.get_info().zone].english) then -- Not in a city:
+        if not settings.ignorezones:contains(res.zones[windower.ffxi.get_info().zone].english) then -- Not in a city:
             put_unneeded_obi(false)
             get_needed_obi(false)
         else -- In a city:
             put_all_obi(false)
         end
     end
-	
-	return true
+    
+    return true
 end
 
 ----------------------------------------

--- a/addons/obiaway/README.md
+++ b/addons/obiaway/README.md
@@ -1,11 +1,14 @@
-Author: ReaperX
-Version: 0.1
-Addon to remove elemental obis based on day/weather/storm conditions. The
-addon is triggered whenever day or weather changes, or a storm effect wears
-off.
+Author: ReaperX, onetime
+Version: 1.0.2
 
-Abbreviation: //Obiaway
+Addon to automatically get and store elemental obis based on day/weather/storm 
+conditions. The addon is triggered whenever on day change, weather change, and
+scholar storm buff gain and loss.
 
-Use //Obiaway to manually move an unneeded elemental Obi to Sack. Usually,
-that won't be necessary.
- 
+Command listing:
+
+//obiaway or //obi
+  (h)elp   - display help information.
+  (g)et   - force obiaway to put away and get appropriate obis.
+  (n)otify [on|off]   - sets notifications on or off.
+  (l)ocation [sack|satchel|case|wardrobe]   - sets where to put obis away.

--- a/addons/obiaway/README.md
+++ b/addons/obiaway/README.md
@@ -9,8 +9,11 @@ Command listing:
 
 //obiaway or //obi
   (h)elp   - display help information.
+   settings   - display current settings
   (s)ort   - force obiaway to put away and get appropriate obis.
   (g)et [ (a)ll | (n)eeded ]   - get obi
   (p)ut [ (a)ll| u(n)needed ]   - put obi
+   lock   - lock obi sorting
+   unlock   - unloack obi sorting
   (n)otify [ on | off ]   - sets notifications on or off.
   (l)ocation [ sack | satchel | case | wardrobe]   - sets where to put obis away.

--- a/addons/obiaway/README.md
+++ b/addons/obiaway/README.md
@@ -10,7 +10,7 @@ Command listing:
 //obiaway or //obi
   (h)elp   - display help information.
   (s)ort   - force obiaway to put away and get appropriate obis.
-  (g)et [(a)ll|(n)eeded)]   - get obi
-  (p)ut [(a)ll|(n)eeded)]   - put obi
-  (n)otify [on|off]   - sets notifications on or off.
-  (l)ocation [sack|satchel|case|wardrobe]   - sets where to put obis away.
+  (g)et [ (a)ll | (n)eeded ]   - get obi
+  (p)ut [ (a)ll| u(n)needed ]   - put obi
+  (n)otify [ on | off ]   - sets notifications on or off.
+  (l)ocation [ sack | satchel | case | wardrobe]   - sets where to put obis away.

--- a/addons/obiaway/README.md
+++ b/addons/obiaway/README.md
@@ -1,5 +1,5 @@
 Author: ReaperX, onetime
-Version: 1.0.3
+Version: 1.0.6
 
 Addon to automatically get and store elemental obis based on day/weather/storm 
 conditions. The addon is triggered on day change, weather change, and scholar
@@ -7,13 +7,11 @@ storm buff gain and loss.
 
 Command listing:
 
-//obiaway or //obi
+//obiaway, //obi, //ob, or //oa
   (h)elp   - display help information.
-   settings   - display current settings
   (s)ort   - force obiaway to put away and get appropriate obis.
   (g)et [ (a)ll | (n)eeded ]   - get obi
-  (p)ut [ (a)ll| u(n)needed ]   - put obi
-   lock   - lock obi sorting
-   unlock   - unloack obi sorting
+  (p)ut [ (a)ll| u(n)needed ] [ sack | satchel | case | wardrobe]  - put obi. location optional
+  (l)ock [ on | off ]  - lock obi sorting
   (n)otify [ on | off ]   - sets notifications on or off.
-  (l)ocation [ sack | satchel | case | wardrobe]   - sets where to put obis away.
+  (loc)ation [ sack | satchel | case | wardrobe]   - sets where to put obis away.

--- a/addons/obiaway/README.md
+++ b/addons/obiaway/README.md
@@ -2,8 +2,8 @@ Author: ReaperX, onetime
 Version: 1.0.2
 
 Addon to automatically get and store elemental obis based on day/weather/storm 
-conditions. The addon is triggered whenever on day change, weather change, and
-scholar storm buff gain and loss.
+conditions. The addon is triggered on day change, weather change, and scholar
+storm buff gain and loss.
 
 Command listing:
 

--- a/addons/obiaway/README.md
+++ b/addons/obiaway/README.md
@@ -1,5 +1,5 @@
 Author: ReaperX, onetime
-Version: 1.0.6
+Version: 1.0.7
 
 Addon to automatically get and store elemental obis based on day/weather/storm 
 conditions. The addon is triggered on day change, weather change, and scholar

--- a/addons/obiaway/README.md
+++ b/addons/obiaway/README.md
@@ -1,5 +1,5 @@
 Author: ReaperX, onetime
-Version: 1.0.2
+Version: 1.0.3
 
 Addon to automatically get and store elemental obis based on day/weather/storm 
 conditions. The addon is triggered on day change, weather change, and scholar
@@ -9,6 +9,8 @@ Command listing:
 
 //obiaway or //obi
   (h)elp   - display help information.
-  (g)et   - force obiaway to put away and get appropriate obis.
+  (s)ort   - force obiaway to put away and get appropriate obis.
+  (g)et [(a)ll|(n)eeded)]   - get obi
+  (p)ut [(a)ll|(n)eeded)]   - put obi
   (n)otify [on|off]   - sets notifications on or off.
   (l)ocation [sack|satchel|case|wardrobe]   - sets where to put obis away.

--- a/addons/obiaway/README.md
+++ b/addons/obiaway/README.md
@@ -1,4 +1,4 @@
-Author: ReaperX, onetime
+Author: ReaperX, bangerang
 Version: 1.0.7
 
 Addon to automatically get and store elemental obis based on day/weather/storm 


### PR DESCRIPTION
- added new commands: //obiaway [help | notify | get]
- obiaway now pulls obi from other inventories as well as puts them away according to weather, day, and SCH buffs.
- stores all obi when entering the following areas (to prevent gearcollector users from having them misplaced):
  
  Ru'Lude Gardens, Upper Jeuno, Lower Jeuno, Port Jeuno, Port Windurst, Windurst Waters, Windurst Woods, Windurst Walls, Heavens Tower, Port San d'Oria, Northern San d'Oria, Southern San d'Oria, Port Bastok, Bastok Markets, Bastok Mines, Metalworks, Aht Urhgan Whitegate, Tavanazian Safehold, Nashmau, Selbina, Mhaura, Norg, Kazham, Eastern Adoulin, Western Adoulin, Leafallia, Celennia Memorial Library, Mog Garden
