### PR TITLE
Add organizer_items, and fix a typo.

### DIFF
--- a/addons/GearSwap/libs/organizer-lib.lua
+++ b/addons/GearSwap/libs/organizer-lib.lua
@@ -22,7 +22,7 @@ function org.export_set()
         return
     end
     
-    -- Makes a big table keyed to item resource tables, iwth values that are 1-based
+    -- Makes a big table keyed to item resource tables, with values that are 1-based
     -- numerically indexed tables of different entries for each of the items from the sets table.
     local item_list = org.unpack_names({},'L1',sets,{})
     
@@ -31,8 +31,7 @@ function org.export_set()
     for i,v in pairs(trans_item_list) do
         trans_item_list[i] = org.simplify_entry(v)
     end
-    
-    
+
     if trans_item_list:length() == 0 then
         windower.add_to_chat(123,'Organizer Library: Your sets table is empty.')
         return
@@ -42,6 +41,16 @@ function org.export_set()
     for name,tab in pairs(trans_item_list) do
         for _,info in ipairs(tab) do
             flattab:append({id=tab.id,name=tab.name,log_name=tab.log_name,augments=info.augments,count=info.count})
+        end
+    end
+
+    -- See if we have any non-equipment items to drag along
+    if organizer_extra then
+        local extra_item_list = org.unpack_names({}, 'L1', organizer_extra, {})
+
+        for _,tab in pairs(org.identify_items(extra_item_list)) do
+            count = gearswap.res.items[tab.id].stack
+            flattab:append({id=tab.id,name=tab.name,log_name=tab.log_name,count=count})
         end
     end
     

--- a/addons/GearSwap/libs/organizer-lib.lua
+++ b/addons/GearSwap/libs/organizer-lib.lua
@@ -45,10 +45,10 @@ function org.export_set()
     end
 
     -- See if we have any non-equipment items to drag along
-    if organizer_extra then
-        local extra_item_list = org.unpack_names({}, 'L1', organizer_extra, {})
+    if organizer_items then
+        local organizer_item_list = org.unpack_names({}, 'L1', organizer_items, {})
 
-        for _,tab in pairs(org.identify_items(extra_item_list)) do
+        for _,tab in pairs(org.identify_items(organizer_item_list)) do
             count = gearswap.res.items[tab.id].stack
             flattab:append({id=tab.id,name=tab.name,log_name=tab.log_name,count=count})
         end

--- a/addons/organizer/ReadMe.md
+++ b/addons/organizer/ReadMe.md
@@ -2,7 +2,7 @@
 
 A multi-purpose inventory management solution. Similar to GearCollector; uses packets.
 
-For the purpose of this addon, a `bag` is: "Safe", "Storage", "Locker", "Satchel", "Sack", "Case", "Wardrobe". 
+For the purpose of this addon, a `bag` is: "Safe", "Storage", "Locker", "Satchel", "Sack", "Case", "Wardrobe", "Safe 2". 
 
 For commands that use a filename, if one is not specified, it defaults to Name_JOB.lua, e.g., Rooks_PLD.lua
 For commands that specify a bag, if one is not specified, it defaults to all, and will cycle through all of them.
@@ -61,3 +61,28 @@ organize [bag] [filename]
 ```
 
 Thaws a frozen state specified by `filename` or **Name_ShortJob.lua** and `bag` or **all bags** and executes repeated Get and Tidy commands until a steady state is reached (aka. you have your gear). With no arguments, it will attempt to restore the entire thawed snapshot.
+
+### Gearswap integration
+Additionally, Organizer integrates with GearSwap. In your lua, just add this:
+
+```
+include('organizer-lib')
+```
+
+And then in your Mog House, after changing jobs:
+
+```
+//gs org
+```
+
+And it will fill your inventory with the items from your sets, and put everything else away (it does a very good job, even when there are space concerns, but it's not perfect. Make sure to do a "//gs validate" after!)
+
+Additionally, if you have extra items you want to bring along, simply define a table named `organizer_items` like so:
+
+```
+organizer_items = {
+    echos="Echo Drops",
+    shihei="Shihei",
+    orb="Macrocosmic Orb"
+}
+```

--- a/addons/organizer/ReadMe.md
+++ b/addons/organizer/ReadMe.md
@@ -86,3 +86,4 @@ organizer_items = {
     orb="Macrocosmic Orb"
 }
 ```
+


### PR DESCRIPTION
Byrth: Up to you, if this is functionality you want to include, since it's still your module.

tl,dr; allows someone to define something like:

organizer_extra = {
   echos="Echo Drops",
   shihei="Shihei",
   orb="Macrocosmic Orb"
}

So they can include things for organizer without making BS sets or polluting gs validate.
