### PR TITLE
Saving there causes problems with character specific settings.

### DIFF
--- a/addons/libs/config.lua
+++ b/addons/libs/config.lua
@@ -61,9 +61,7 @@ function config.load(filepath, defaults)
         config.save(settings, 'all')
     end
 
-    local res = parse(settings)
-    config.save(settings)
-    return res
+    return parse(settings)
 end
 
 -- Reloads the settings for the provided table. Needs to be the same table that was assigned to with config.load.


### PR DESCRIPTION
If you have a `<global>` block, and a `<character_name>` block, this save will overwrite <global> when character_name loads. It used to be like this, and it changed, but it isn't obviously apparent why it was changed. Can it be changed back?
