### PR TITLE
[gearswap]added extdata to  player.<bag> info

### DIFF
--- a/addons/GearSwap/refresh.lua
+++ b/addons/GearSwap/refresh.lua
@@ -584,7 +584,7 @@ function refresh_item_list(itemlist)
             -- If we don't already have the primary item name in the table, add it.
             if res.items[v.id] and res.items[v.id][language] and not retarr[res.items[v.id][language]] then
                 -- We add the entry as a sub-table containing the id and count
-                retarr[res.items[v.id][language]] = {id=v.id, count=v.count, shortname=res.items[v.id][language]:lower()}
+                retarr[res.items[v.id][language]] = {id=v.id, count=v.count, extdata = extdata.decode(v), shortname=res.items[v.id][language]:lower()}
                 -- If a long version of the name exists, and is different from the short version,
                 -- add the long name to the info table and point the long name's key at that table.
                 if res.items[v.id][language..'_log'] and res.items[v.id][language..'_log']:lower() ~= res.items[v.id][language]:lower() then

--- a/addons/GearSwap/refresh.lua
+++ b/addons/GearSwap/refresh.lua
@@ -126,7 +126,7 @@ function load_user_files(job_id,user_file)
         loadstring=loadstring,assert=assert,error=error,pcall=pcall,io=io,dofile=dofile,
         
         debug=debug,coroutine=coroutine,setmetatable=setmetatable,getmetatable=getmetatable,
-        rawset=rawset,rawget=rawget,require=include_user,
+        rawset=rawset,rawget=rawget,require=include_user,extdata=extdata,
         
         -- Player environment things
         buffactive=buffactive,
@@ -584,7 +584,7 @@ function refresh_item_list(itemlist)
             -- If we don't already have the primary item name in the table, add it.
             if res.items[v.id] and res.items[v.id][language] and not retarr[res.items[v.id][language]] then
                 -- We add the entry as a sub-table containing the id and count
-                retarr[res.items[v.id][language]] = {id=v.id, count=v.count, extdata = extdata.decode(v), shortname=res.items[v.id][language]:lower()}
+                retarr[res.items[v.id][language]] = {id=v.id, count=v.count, extdata = v.extdata, shortname=res.items[v.id][language]:lower()}
                 -- If a long version of the name exists, and is different from the short version,
                 -- add the long name to the info table and point the long name's key at that table.
                 if res.items[v.id][language..'_log'] and res.items[v.id][language..'_log']:lower() ~= res.items[v.id][language]:lower() then


### PR DESCRIPTION
i added extdata to the player.<bag> item info as this data is useful in many ways even from inside gearswap user files

example(to get the time(server aka GMT) when you can use an item again):

```
function get_item_next_use(name)--returns time remaining till items next use
    if player.wardrobe[name] then
        return player.wardrobe[name].extdata.next_use_time
    elseif player.inventory[name] then
        return player.inventory[name].extdata.next_use_time
    end
end
```

im hoping that this is accepted and pushed quickly(both live and dev)
