### PR TITLE
fix for windows xp

### DIFF
--- a/addons/GearSwap/gearswap.lua
+++ b/addons/GearSwap/gearswap.lua
@@ -255,6 +255,11 @@ function disenable(tab,funct,functname,pol)
     end
 end
 
+
+function to_windower_compact(str)
+    return __raw.lower(str:gsub(' ',''))
+end
+
 windower.register_event('incoming chunk',function(id,data,modified,injected,blocked)
     windower.debug('incoming chunk '..id)
     
@@ -356,7 +361,7 @@ windower.register_event('incoming chunk',function(id,data,modified,injected,bloc
             end
             encumbrance_table[slot_id] = tf
         end
-        if table.length(tab) > 0 then
+        if tab and table.length(tab) > 0 then
             refresh_globals()
             equip_sets('equip_command',nil,tab)
         end


### PR DESCRIPTION
With these changes Gearswap appears to function correctly on windows XP SP3 32-bit.  I know XP isn't supported anymore, but with my configuration windows7 (32 and 64 bit) has substantially lower framerates when in intense action compared to XP.

I'm not sure why these changes are needed on windows XP only and not win7, but I needed to add the to_windower_compact function directly into gearswap.lua to get the addon to load, and I had to add the nil check or a runtime error would occur.
