### PR TITLE
Scoreboard - add adventuring fellow

### DIFF
--- a/addons/scoreboard/readme.txt
+++ b/addons/scoreboard/readme.txt
@@ -98,6 +98,7 @@ additional configuration options:
 * sbcolor - Color of scoreboard's chat log output
 * showallidps - Set to true to display the alliance DPS, false otherwise.
 * resetfilters - Set to true if you want filters reset when you "//sb reset", false otherwise.
+* showfellow - Set to true to display your adventuring fellow's DPS, false otherwise.
  
 Caveats:
 * DPS is an approximation, although I tested it manually and found it to

--- a/addons/scoreboard/scoreboard.lua
+++ b/addons/scoreboard/scoreboard.lua
@@ -27,6 +27,7 @@ default_settings.sbcolor = 204
 default_settings.showallidps = true
 default_settings.resetfilters = true
 default_settings.visible = true
+default_settings.showfellow = true
 default_settings.UpdateFrequency = 0.5
 
 default_settings.display = {}
@@ -149,6 +150,18 @@ windower.register_event('addon command', function()
                 
                 settings:save()
                 sb_output("Setting 'resetfilters' set to " .. tostring(settings.resetfilters))
+            elseif setting == 'showfellow' then
+                if params[2] == 'true' then
+                    settings.showfellow = true
+                elseif params[2] == 'false' then
+                    settings.showfellow = false
+                else
+                    error("Invalid value for 'showfellow'. Must be true or false.")
+                    return
+                end
+                
+                settings:save()
+                sb_output("Setting 'showfellow' set to " .. tostring(settings.showfellow))
             end
         elseif command == 'reset' then
             reset()
@@ -343,10 +356,11 @@ function get_ally_mob_ids()
         end
     end
 
-    -- add adventuring fellow
-    local fellow = windower.ffxi.get_mob_by_target("ft")
-    if fellow ~= nil then
-        allies:append(fellow.id)
+    if settings.showfellow then
+        local fellow = windower.ffxi.get_mob_by_target("ft")
+        if fellow ~= nil then
+            allies:append(fellow.id)
+        end
     end
     
     return allies

--- a/addons/scoreboard/scoreboard.lua
+++ b/addons/scoreboard/scoreboard.lua
@@ -342,6 +342,12 @@ function get_ally_mob_ids()
             end
         end
     end
+
+    -- add adventuring fellow
+    local fellow = windower.ffxi.get_mob_by_target("ft")
+    if fellow ~= nil then
+        allies:append(fellow.id)
+    end
     
     return allies
 end


### PR DESCRIPTION
Fix issue #1332 

Note the windower API only seems to allow getting the ID for the current player's fellow, so I only added the player's fellow to scoreboard. Not sure if there's a way to get the fellow ID of party members / allies.
