### PR TITLE
Libs/Packets/Fields: Fixed 0x068

### DIFF
--- a/addons/libs/packets/fields.lua
+++ b/addons/libs/packets/fields.lua
@@ -2844,8 +2844,8 @@ fields.incoming[0x068] = L{
     {ctype='unsigned short',    label='Owner Index',        fn=index},          -- 0C
     {ctype='unsigned int',      label='Owner ID',           fn=id},             -- 08
     {ctype='unsigned short',    label='Pet Index',          fn=index},          -- 0C
-    {ctype='unsigned char',     label='Current MP%',        fn=percent},        -- 0E
-    {ctype='unsigned char',     label='Current HP%',        fn=percent},        -- 0F
+    {ctype='unsigned char',     label='Current HP%',        fn=percent},        -- 0E
+    {ctype='unsigned char',     label='Current MP%',        fn=percent},        -- 0F
     {ctype='unsigned int',      label='Pet TP'},                                -- 10
     {ctype='unsigned int',      label='Target ID',          fn=id},             -- 14
     {ctype='char*',             label='Pet Name'},                              -- 18


### PR DESCRIPTION
The HP/MP fields of 0x068 are currently reversed:

![example](http://i.imgur.com/1hkYFZN.jpg)
