### PR TITLE
Update MobCompass.lua

### DIFF
--- a/addons/MobCompass/MobCompass.lua
+++ b/addons/MobCompass/MobCompass.lua
@@ -223,11 +223,11 @@ do
             end
             local next45angle = math.ceil((angle+pi/8)/(pi/4))
             if next45angle ~= last45angle then
-            	if next45angle ~= nil and last45angle ~=nil then
-                arrow_map[last45angle]:color(255,255,255)
-                arrow_map[next45angle]:color(255,0,0)
-                last45angle = next45angle
-            end
+                if next45angle ~= nil and last45angle ~=nil then
+                    arrow_map[last45angle]:color(255,255,255)
+                    arrow_map[next45angle]:color(255,0,0)
+                    last45angle = next45angle
+                end
             end
             local heading = mob.facing
             if heading < 0 then

--- a/addons/MobCompass/MobCompass.lua
+++ b/addons/MobCompass/MobCompass.lua
@@ -223,7 +223,7 @@ do
             end
             local next45angle = math.ceil((angle+pi/8)/(pi/4))
             if next45angle ~= last45angle then
-			   if next45angle ~= nil and last45angle ~=nil then
+            	if next45angle ~= nil and last45angle ~=nil then
                 arrow_map[last45angle]:color(255,255,255)
                 arrow_map[next45angle]:color(255,0,0)
                 last45angle = next45angle

--- a/addons/MobCompass/MobCompass.lua
+++ b/addons/MobCompass/MobCompass.lua
@@ -27,7 +27,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ]]
 
 _addon.name = 'MobCompass'
-_addon.version = '2.0'
+_addon.version = '2.0.1'
 
 texts = require('texts')
 config = require('config')
@@ -223,9 +223,11 @@ do
             end
             local next45angle = math.ceil((angle+pi/8)/(pi/4))
             if next45angle ~= last45angle then
+			   if next45angle ~= nil and last45angle ~=nil then
                 arrow_map[last45angle]:color(255,255,255)
                 arrow_map[next45angle]:color(255,0,0)
                 last45angle = next45angle
+            end
             end
             local heading = mob.facing
             if heading < 0 then


### PR DESCRIPTION
Addresses a bug where if the PC is on top of target, nil error is thrown ad infinitum.

Adds a simple added if statement checking if the positional difference is nil, which occurs most often when a PC uses a home point crystal to port to another location and targets another player right under them.
