### PR TITLE
"no argument" commands - Fix

### DIFF
--- a/addons/scoreboard/scoreboard.lua
+++ b/addons/scoreboard/scoreboard.lua
@@ -75,13 +75,8 @@ windower.register_event('addon command', function()
             assert(loadstring(table.concat({...}, ' ')))()
             return
         end
-        
-        if command == nil then
-	    error('No command given. See //sb help')
-            return
-        end
 
-        command = command:lower() or 'help'
+        command = (command or 'help'):lower()
         local params = {...}
 
         if command == 'help' then

--- a/addons/scoreboard/scoreboard.lua
+++ b/addons/scoreboard/scoreboard.lua
@@ -2,7 +2,7 @@
 
 _addon.name = 'Scoreboard'
 _addon.author = 'Suji'
-_addon.version = '1.10'
+_addon.version = '1.11'
 _addon.commands = {'sb', 'scoreboard'}
 
 require('tables')
@@ -73,6 +73,11 @@ windower.register_event('addon command', function()
     return function(command, ...)
         if command == 'e' then
             assert(loadstring(table.concat({...}, ' ')))()
+            return
+        end
+        
+        if command == nil then
+	    error('No command given. See //sb help')
             return
         end
 


### PR DESCRIPTION
This is a fix for Scoreboard - Fails to handle "no argument" commands
#1389 issue.
