### PR TITLE
Scoreboard - Add ability to report on weapon skill accuracy

### DIFF
--- a/addons/scoreboard/damagedb.lua
+++ b/addons/scoreboard/damagedb.lua
@@ -18,7 +18,7 @@ DamageDB.player_stat_fields = T{
     'mavg', 'mrange', 'critavg', 'critrange',
     'ravg', 'rrange', 'rcritavg', 'rcritrange',
     'acc', 'racc', 'crit', 'rcrit',
-    'wsavg'
+    'wsavg', 'wsacc'
 }
 
 function DamageDB:new (o)
@@ -142,6 +142,7 @@ function DamageDB:add_r_hit(m, p, d)         self:_get_player(m, p):add_r_hit(d)
 function DamageDB:add_r_crit(m, p, d)        self:_get_player(m, p):add_r_crit(d)        end
 function DamageDB:incr_misses(m, p)          self:_get_player(m, p):incr_m_misses()      end
 function DamageDB:incr_r_misses(m, p)        self:_get_player(m, p):incr_r_misses()      end
+function DamageDB:incr_ws_misses(m, p)       self:_get_player(m, p):incr_ws_misses()     end
 function DamageDB:add_damage(m, p, d)        self:_get_player(m, p):add_damage(d)        end
 function DamageDB:add_ws_damage(m, p, d, id) self:_get_player(m, p):add_ws_damage(id, d) end
 

--- a/addons/scoreboard/display.lua
+++ b/addons/scoreboard/display.lua
@@ -364,6 +364,7 @@ Display.stat_summaries._all_stats = T{
     ['crit']       = {percent=true,  category="average", name='Melee Crit. Rate'},
     ['rcrit']      = {percent=true,  category="average", name='Ranged Crit. Rate'},
     ['wsavg']      = {percent=false, category="average", name='WS Average'}, 
+    ['wsacc']      = {percent=true,  category="average", name='WS Accuracy'}, 
     ['mavg']       = {percent=false, category="average", name='Melee Non-Crit. Avg. Damage'},
     ['mrange']     = {percent=false, category="range",   name='Melee Non-Crit. Range'},
     ['critavg']    = {percent=false, category="average", name='Melee Crit. Avg. Damage'},

--- a/addons/scoreboard/mergedplayer.lua
+++ b/addons/scoreboard/mergedplayer.lua
@@ -234,8 +234,21 @@ function MergedPlayer:wsavg()
     end
 end
 
-
-
+function MergedPlayer:wsacc()
+    local hits, misses = 0, 0, 0
+    
+    for _, p in ipairs(self.players) do
+        for _ in pairs(p.ws) do hits = hits + 1 end
+        misses = misses + p.ws_misses
+    end
+    
+    local total = hits + misses
+    if total > 0 then
+        return {hits / total, total}
+    else
+        return {0, 0}
+    end
+end
 
 -- Unused atm
 function MergedPlayer:merge(other)

--- a/addons/scoreboard/mergedplayer.lua
+++ b/addons/scoreboard/mergedplayer.lua
@@ -238,7 +238,7 @@ function MergedPlayer:wsacc()
     local hits, misses = 0, 0
     
     for _, p in ipairs(self.players) do
-        for _ in pairs(p.ws) do hits = hits + 1 end
+        hits = hits + table.length(p.ws)
         misses = misses + p.ws_misses
     end
     

--- a/addons/scoreboard/mergedplayer.lua
+++ b/addons/scoreboard/mergedplayer.lua
@@ -235,7 +235,7 @@ function MergedPlayer:wsavg()
 end
 
 function MergedPlayer:wsacc()
-    local hits, misses = 0, 0, 0
+    local hits, misses = 0, 0
     
     for _, p in ipairs(self.players) do
         for _ in pairs(p.ws) do hits = hits + 1 end

--- a/addons/scoreboard/player.lua
+++ b/addons/scoreboard/player.lua
@@ -17,6 +17,7 @@ function Player:new (o)
         clock = nil,            -- specific DPS clock for this player
         damage = 0,             -- total damage done by this player
         ws  = T{},              -- table of all WS and their corresponding damage
+        ws_misses = 0,          -- total ws misses
         m_hits = 0,             -- total melee hits
         m_misses = 0,           -- total melee misses
         m_min = math.huge,      -- minimum melee damage
@@ -107,6 +108,7 @@ end
 
 function Player:incr_m_misses() self.m_misses = self.m_misses + 1 end
 
+function Player:incr_ws_misses() self.ws_misses = self.ws_misses + 1 end
 
 function Player:add_r_hit(damage)
     -- increment hits

--- a/addons/scoreboard/readme.txt
+++ b/addons/scoreboard/readme.txt
@@ -43,7 +43,7 @@ Command list:
   RS <stat> [<playerName>] [<target>]
   Reports the given stat. Supported stats are:
       mavg, mrange, acc, ravg, rrange, racc, critavg, critrange, crit,
-      rcritavg, rcritrange, rcrit, wsavg
+      rcritavg, rcritrange, rcrit, wsavg, wsacc
   
   'playerName' may be the name of a player if you wish to see only one player.
   

--- a/addons/scoreboard/scoreboard.lua
+++ b/addons/scoreboard/scoreboard.lua
@@ -416,6 +416,8 @@ function action_handler(raw_actionpacket)
                     dps_db:add_r_crit(target:get_name(), create_mob_name(actionpacket), main.param)
                 elseif main.message_id == 354 then
                     dps_db:incr_r_misses(target:get_name(), create_mob_name(actionpacket))
+                elseif main.message_id == 188 then
+                    dps_db:incr_ws_misses(target:get_name(), create_mob_name(actionpacket))
                 elseif main.resource and main.resource == 'weapon_skills' and main.conclusion then
                     dps_db:add_ws_damage(target:get_name(), create_mob_name(actionpacket), main.param, main.spell_id)
                 elseif main.conclusion then


### PR DESCRIPTION
Hello,

This change adds the ability to see your overall weapon skill accuracy via `sb reportstat wsacc`. This is accomplished by incrementing a count for every missed ws and comparing to the total number of data points in the ws damage table.

I arrived at `message_id` 188 for missed skills through trial and error. If there is a better way to track these instances just let me know and I can modify it.

Thanks!

![ffxi_2016 05 15_11 25 36](https://cloud.githubusercontent.com/assets/744664/15275138/501d65ee-1a91-11e6-878e-0da8a605192e.png)
