### PR TITLE
Fixing up packets\fields.lua 0x03c

### DIFF
--- a/addons/libs/packets/fields.lua
+++ b/addons/libs/packets/fields.lua
@@ -2098,6 +2098,7 @@ types.shop_item = L{
     {ctype='unsigned int',      label='Price',              fn=gil},            -- 00
     {ctype='unsigned short',    label='Item',               fn=item},           -- 04
     {ctype='unsigned short',    label='Shop Slot'},                             -- 08
+	{ctype='unsigned short',    label='Craft Skill'},                           -- Zero on normal shops, has values that correlate to res\skills.
 	{ctype='unsigned short',    label='Craft Rank'},                            -- Correlates to Rank able to purchase product from GuildNPC
 }
 

--- a/addons/libs/packets/fields.lua
+++ b/addons/libs/packets/fields.lua
@@ -2098,7 +2098,6 @@ types.shop_item = L{
     {ctype='unsigned int',      label='Price',              fn=gil},            -- 00
     {ctype='unsigned short',    label='Item',               fn=item},           -- 04
     {ctype='unsigned short',    label='Shop Slot'},                             -- 08
-	{ctype='unsigned short',    label='Craft Skill'}                            -- Shows up on Guild NPCs.  Unknown.
 	{ctype='unsigned short',    label='Craft Rank'},                            -- Correlates to Rank able to purchase product from GuildNPC
 }
 

--- a/addons/libs/packets/fields.lua
+++ b/addons/libs/packets/fields.lua
@@ -2098,8 +2098,8 @@ types.shop_item = L{
     {ctype='unsigned int',      label='Price',              fn=gil},            -- 00
     {ctype='unsigned short',    label='Item',               fn=item},           -- 04
     {ctype='unsigned short',    label='Shop Slot'},                             -- 08
-	{ctype='unsigned short',    label='Craft Skill'},                           -- Zero on normal shops, has values that correlate to res\skills.
-	{ctype='unsigned short',    label='Craft Rank'},                            -- Correlates to Rank able to purchase product from GuildNPC
+    {ctype='unsigned short',    label='Craft Skill'},                           -- Zero on normal shops, has values that correlate to res\skills.
+    {ctype='unsigned short',    label='Craft Rank'},                            -- Correlates to Rank able to purchase product from GuildNPC
 }
 
 -- Shop

--- a/addons/libs/packets/fields.lua
+++ b/addons/libs/packets/fields.lua
@@ -2098,6 +2098,8 @@ types.shop_item = L{
     {ctype='unsigned int',      label='Price',              fn=gil},            -- 00
     {ctype='unsigned short',    label='Item',               fn=item},           -- 04
     {ctype='unsigned short',    label='Shop Slot'},                             -- 08
+	{ctype='unsigned short',    label='Craft Skill'}                            -- Shows up on Guild NPCs.  Unknown.
+	{ctype='unsigned short',    label='Craft Rank'},                            -- Correlates to Rank able to purchase product from GuildNPC
 }
 
 -- Shop


### PR DESCRIPTION
Adding 'Craft Skill' and 'Craft Rank' unsigned shorts to fields.lua to
correctly track that incoming 0x03c packet.