### PR TITLE
Library refactoring interferes with GearSwap's include_user function

### DIFF
--- a/addons/GearSwap/refresh.lua
+++ b/addons/GearSwap/refresh.lua
@@ -112,7 +112,7 @@ function load_user_files(job_id,user_file)
         sets = nil
         return
     end
-    
+
     user_env = {gearswap = _G, _global = _global, _settings = _settings,_addon=_addon,
         -- Player functions
         equip = equip, cancel_spell=cancel_spell, change_target=change_target, cast_delay=cast_delay,
@@ -124,7 +124,7 @@ function load_user_files(job_id,user_file)
         language=language,
         
         -- Library functions
-        string=string,math=math,table=table,set=set,list=list,T=T,S=S,L=L,pack=pack,
+        string=string,math=math,table=table,set=set,list=list,T=T,S=S,L=L,pack=pack,functions=functions,
         os=os,texts=texts,type=type,tostring=tostring,tonumber=tonumber,pairs=pairs,
         ipairs=ipairs, print=print, add_to_chat=add_to_chat_user,unpack=unpack,next=next,
         select=select,lua_base_path=windower.addon_path,empty=empty,file=file,
@@ -132,6 +132,7 @@ function load_user_files(job_id,user_file)
         
         debug=debug,coroutine=coroutine,setmetatable=setmetatable,getmetatable=getmetatable,
         rawset=rawset,rawget=rawget,require=include_user,
+        _libs=_libs,
         
         -- Player environment things
         buffactive=buffactive,

--- a/addons/GearSwap/user_functions.lua
+++ b/addons/GearSwap/user_functions.lua
@@ -302,7 +302,9 @@ function include_user(str, load_include_in_this_table)
         error('\nGearSwap: include() was passed an invalid value ('..tostring(str)..'). (must be a string)', 2)
     end
     
-    if T{'bit','socket','mime'}:contains(str:lower()) then
+    if T{'math', 'string', 'table', 'coroutine'}:contains(str:lower()) then
+        return package.loaded[str]
+    elseif T{'bit','socket','mime'}:contains(str:lower()) then
         return _G[str:lower()]
     elseif T{'pack'}:contains(str:lower()) then
         return


### PR DESCRIPTION
@Byrth Is this ok? This should patch any incompatibilities with the changes I made to the libraries (sorry!).

This adds the _libs and functions tables to GearSwap's user_env table,
and adds a check to package.loaded for basic Lua tables within
include_user.