### PR TITLE
New Addon Request: SkillUp

### DIFF
--- a/addons/Skillup/Skillup.lua
+++ b/addons/Skillup/Skillup.lua
@@ -1,0 +1,94 @@
+--[[
+Copyright © 2018 Iminiillusions of Asura (Formerly of Quetzalcoatl).
+All rights reserved.
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of Skillup nor the
+      names of its contributors may be used to endorse or promote products
+      derived from this software without specific prior written permission.
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL Iminiillusions BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+]]
+
+
+
+_addon.name = 'skillup'
+_addon.author = 'Iminiillusions of Asura (Formerly of Quetzalcoatl)'
+_addon.version = '1.0.1'
+_addon.commands = {'skillup','su','skill'}
+
+
+require('chat')
+
+delay = 6.5  -- how much delay in between spells
+
+spell_list = T{ --What spells each type of skillup uses
+	['healing'] = {
+		'Cure', 
+		'Cure II'
+		},
+	['enhancing'] = {
+		'Protect',
+		'Protect II'
+		},
+	['blu'] = {
+		'Pollen',
+		'Wild Carrot'
+		},
+	['geo'] = {
+		'Indi-Poison',
+		'Indi-Voidance',
+		}
+	['brd'] = {
+		"Knight's Minne",
+		'Army Paeon',
+		},
+	['nin'] = {
+		'Utsusemi: Ichi',
+		'Utsusemi: Ni',
+		},
+	
+}
+
+
+continue = false
+
+windower.register_event('addon command', function(command, skill)
+		if command == 'help' then
+			display_help()
+		elseif command == 'stop' then
+			continue = false
+		elseif command == 'start' then
+			continue = true
+			skill_up(skill)
+		end
+end)
+
+function skill_up(skill) --The logic to actually start the skillup
+	while continue do 
+		for i,v, spell in pairs(spell_list[skill]) do
+			windower.send_command('input /ma '..v..' <me>')
+			coroutine.sleep(delay)
+		end
+	end
+end
+
+function display_help()
+	windower.add_to_chat(7, 'SkillUp v. 1.0.1 by Iminiillusions of Asura (Formerly of Quetzalcoatl)')
+	windower.add_to_chat(7, 'Usage: //skillup start healing | enhancing | blu | geo| brd | nin')
+	windower.add_to_chat(7, 'To Stop: //skillup stop')
+	windower.add_to_chat(7, 'Command alias: /sc')
+end

--- a/addons/addons.xml
+++ b/addons/addons.xml
@@ -491,6 +491,7 @@
     <name>Scoreboard</name>
     <author>Suji</author>
     <description>Basic in-game damage parser. It displays live DPS and works even when chat filters are enabled.</description>
+
     <bugtracker>https://github.com/jerryhebert/Lua/issues</bugtracker>
     <support>https://discord.gg/b275nMv</support>
   </addon>
@@ -528,6 +529,13 @@
     <description>Sends commands between windower instances using IPC.</description>
     <bugtracker>https://github.com/Windower/Lua/issues</bugtracker>
     <support>https://discord.gg/b275nMv</support>
+  </addon>
+  <addon>
+	  <name>SkillUp</name>
+	  <author>Iminiillusions of Asura</author>
+	  <description>An easy skill up bot for self target magic types.</description>
+	  <bugtracker>https://www.github.com/Windower/Lua/issues</bugtracker>
+	  <support>https://github.com/Iminiillusions/Windower4-Addons/issues</support>
   </addon>
   <addon>
     <name>SpeedChecker</name>

--- a/addons/addons.xml
+++ b/addons/addons.xml
@@ -442,8 +442,7 @@
     <name>Remember</name>
     <author>Byrth</author>
     <description>Should request spawn packets for players / mobile NPCs that failed to spawn.</description>
-    <bugtracker>https://github.com/Byrth/Lua-Byrth/issues</bugtracker>
-    <support>https://discord.gg/b275nMv</support>
+    <bugtracker>https://github.com/Byrth/Lua-Byrth/issues</bugtracker>    <support>https://discord.gg/b275nMv</support>
   </addon>
   <addon>
     <name>Respond</name>
@@ -453,8 +452,7 @@
     <support>https://discord.gg/b275nMv</support>
   </addon>
   <addon>
-    <name>Rhombus</name>
-    <description>Creates a highly customizable, click-able, on-screen menu.</description>
+    <name>Rhombus</name>    <description>Creates a highly customizable, click-able, on-screen menu.</description>
     <author>trv</author>
     <support>https://discord.gg/b275nMv</support>
     <bugtracker>https://github.com/trv6/Lua/issues</bugtracker>
@@ -491,7 +489,6 @@
     <name>Scoreboard</name>
     <author>Suji</author>
     <description>Basic in-game damage parser. It displays live DPS and works even when chat filters are enabled.</description>
-
     <bugtracker>https://github.com/jerryhebert/Lua/issues</bugtracker>
     <support>https://discord.gg/b275nMv</support>
   </addon>

--- a/addons/addons.xml
+++ b/addons/addons.xml
@@ -531,11 +531,11 @@
     <support>https://discord.gg/b275nMv</support>
   </addon>
   <addon>
-	  <name>SkillUp</name>
-	  <author>Iminiillusions of Asura</author>
-	  <description>An easy skill up bot for self target magic types.</description>
-	  <bugtracker>https://www.github.com/Windower/Lua/issues</bugtracker>
-	  <support>https://github.com/Iminiillusions/Windower4-Addons/issues</support>
+    <name>SkillUp</name>
+    <author>Iminiillusions of Asura</author>
+    <description>An easy skill up bot for self target magic types.</description>
+    <bugtracker>https://www.github.com/Windower/Lua/issues</bugtracker>
+    <support>https://github.com/Iminiillusions/Windower4-Addons/issues</support>
   </addon>
   <addon>
     <name>SpeedChecker</name>


### PR DESCRIPTION
SkillUp is a very easy to use skill up bot for self targeted magic types, such as enhancing magic and healing magic.