### PR TITLE
[Update] libs/extdata.lua

### DIFF
--- a/addons/libs/extdata.lua
+++ b/addons/libs/extdata.lua
@@ -305,7 +305,7 @@ augment_values = {
         [0x15E] = {{stat="Occ. maximizes magic accuracy ", offset=1,percent=true}},
         [0x15F] = {{stat="Occ. quickens spellcasting ", offset=1,percent=true}},
         [0x160] = {{stat="Occ. grants dmg. bonus based on TP ", offset=1,percent=true}},
-        [0x161] = {{stat="TP Bonus ", offset=1, multiplier=5}},
+        [0x161] = {{stat="TP Bonus ", offset=1, multiplier=50}},
         [0x162] = {{stat="Quadruple Attack ", offset=1}},
 
         [0x164] = {{stat='Potency of "Cure" effect received', offset=1, percent=true}},


### PR DESCRIPTION
Modified the result to be 10x. (since post 2014)
I haven't validate other TP things yet.
```lua
-- equip 'Moonshade Earring' with 'TP Bonus+250' aug in right_ear before exec this.
extdata = require('extdata')
local get_items = windower.ffxi.get_items
bag = get_items().equipment.right_ear_bag
ind = get_items().equipment.right_ear
aug = extdata.decode({id=11697,extdata=get_items(bag,ind).extdata}).augments
for i,v in ipairs(aug) do
    print(i,v) --TP Bonus+25
end
```