### PR TITLE
GearSwap v0.934 - Fixed /item command handling

### DIFF
--- a/addons/GearSwap/flow.lua
+++ b/addons/GearSwap/flow.lua
@@ -252,15 +252,12 @@ function equip_sets_exit(swap_type,ts,val1)
             if val1.target and val1.target.id and val1.target.index and val1.prefix and unify_prefix[val1.prefix] then
                 if val1.prefix == '/item' then
                     -- Item use packet handling here
-                    if val1.target.spawn_type == 2 then
-                        --0x36 packet
+                    if bit.band(val1.target.spawn_type, 2) == 2 and find_inventory_item(val1.id) then
+                        -- 0x36 packet
                         command_registry[ts].proposed_packet = assemble_menu_item_packet(val1.target.id,val1.target.index,val1.id)
-                    elseif find_usable_item(val1.id,true) then --val1.target.id == player.id then
-                        --0x37 packet
+                    elseif find_usable_item(val1.id) then
+                        -- 0x37 packet
                         command_registry[ts].proposed_packet = assemble_use_item_packet(val1.target.id,val1.target.index,val1.id)
-                    else
-                        --0x36 packet
-                        command_registry[ts].proposed_packet = assemble_menu_item_packet(val1.target.id,val1.target.index,val1.id)
                     end
                     if not command_registry[ts].proposed_packet then
                         command_registry:delete_entry(ts)

--- a/addons/GearSwap/gearswap.lua
+++ b/addons/GearSwap/gearswap.lua
@@ -25,7 +25,7 @@
 --SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 _addon.name = 'GearSwap'
-_addon.version = '0.933'
+_addon.version = '0.934'
 _addon.author = 'Byrth'
 _addon.commands = {'gs','gearswap'}
 

--- a/addons/GearSwap/triggers.lua
+++ b/addons/GearSwap/triggers.lua
@@ -135,15 +135,12 @@ windower.register_event('outgoing text',function(original,modified,blocked,ffxi,
                     
                     if spell.prefix == '/item' then
                         -- Item use packet handling here
-                        if spell.target.spawn_type == 2 then
+                        if bit.band(spell.target.spawn_type, 2) == 2 and find_inventory_item(spell.id) then
                             --0x36 packet
                             command_registry[ts].proposed_packet = assemble_menu_item_packet(spell.target.id,spell.target.index,spell.id)
-                        elseif find_usable_item(spell.id,true) then
+                        elseif find_usable_item(spell.id) then
                             --0x37 packet
                             command_registry[ts].proposed_packet = assemble_use_item_packet(spell.target.id,spell.target.index,spell.id)
-                        else
-                            --0x36 packet
-                            command_registry[ts].proposed_packet = assemble_menu_item_packet(spell.target.id,spell.target.index,spell.id)
                         end
                     else
                         command_registry[ts].proposed_packet = assemble_action_packet(spell.target.id,spell.target.index,outgoing_action_category_table[unify_prefix[spell.prefix]],spell.id,initialize_arrow_offset(spell.target))

--- a/addons/GearSwap/version_history.txt
+++ b/addons/GearSwap/version_history.txt
@@ -1,4 +1,7 @@
 -------------------------------------------------
+
+GearSwap 0.934 - Fixed /item command handling.
+-------------------------------------------------
 GearSwap 0.933 - Adjusted how item use packets are chosen. 
 -------------------------------------------------
 GearSwap 0.932 - Fixed bug that prevented gearswap from identifying items by their bag when worn. 


### PR DESCRIPTION
@Byrth Apparently, spawn_type is a bitfield. The second bit is a flag for NPC's, so spawn_type == 2 was excluding a few cases. This now selects item use packets in the same way the client does in each of my tests. With the added bonus of trading NPC's unequipped enchanted equipment when the command would have otherwise been ignored.