### PR TITLE
corrected spelling for city Tavnazian Safehold

### DIFF
--- a/addons/GearSwap/libs/Mote-Mappings.lua
+++ b/addons/GearSwap/libs/Mote-Mappings.lua
@@ -234,7 +234,7 @@ areas.Cities = S{
     "Bastok Mines",
     "Metalworks",
     "Aht Urhgan Whitegate",
-    "Tavanazian Safehold",
+    "Tavnazian Safehold",
     "Nashmau",
     "Selbina",
     "Mhaura",


### PR DESCRIPTION
I noticed my city gear wasn't triggering in Tavnazian.  fixed spelling typo, now it triggers.