### PR TITLE
Fix incoming sparks field

### DIFF
--- a/addons/libs/packets/fields.lua
+++ b/addons/libs/packets/fields.lua
@@ -3506,8 +3506,7 @@ fields.incoming[0x10B] = L{
 
 -- Sparks update packet
 fields.incoming[0x110] = L{
-    {ctype='unsigned short',    label='Sparks Total'},                          -- 04
-    {ctype='unsigned short',    label='_unknown1'},                             -- 06   Sparks are currently capped at 50,000
+    {ctype='unsigned int',      label='Sparks Total'},                          -- 04
     {ctype='unsigned char',     label='Unity (Shared) designator'},             -- 08   Unity (Shared) designator (0=A, 1=B, 2=C, etc.)
     {ctype='unsigned char',     label='Unity (Person) designator '},            -- 09   The game does not distinguish these
     {ctype='char[6]',           label='_unknown2'},                             -- 0A   Currently all 0xFF'd, never seen it change.


### PR DESCRIPTION
As sparks are no longer capped at 50,000, use an unsigned int for sparks quantity rather than unsigned short.