### PR TITLE
Update fields for incoming price response packet (0x03D) from using 'Bag' to 'Type'

### DIFF
--- a/addons/libs/packets/data.lua
+++ b/addons/libs/packets/data.lua
@@ -152,7 +152,7 @@ data.incoming[0x038] = {name='Entity Animation',    description='Sent when a mod
 data.incoming[0x039] = {name='Env. Animation',      description='Sent to force animations to specific objects.'}
 data.incoming[0x03A] = {name='Independ. Animation', description='Used for arbitrary battle animations that are unaccompanied by an action packet.'}
 data.incoming[0x03C] = {name='Shop',                description='Displays items in a vendors shop.'}
-data.incoming[0x03D] = {name='Value',               description='Returns the value of an item.'}
+data.incoming[0x03D] = {name='Shop Value/Sale',     description='Returns the value of an item or notice it has been sold.'}
 data.incoming[0x03E] = {name='Open Buy/Sell',       description='Opens the buy/sell menu for vendors.'}
 data.incoming[0x03F] = {name='Shop Buy Response',   description='Sent when you buy something from normal vendors.'}
 data.incoming[0x041] = {name='Blacklist',           description='Contains player ID and name for blacklist.'}

--- a/addons/libs/packets/fields.lua
+++ b/addons/libs/packets/fields.lua
@@ -2132,12 +2132,13 @@ fields.incoming[0x03C] = L{
     {ref=types.shop_item,       label='Item',               count='*'},         -- 08 -   *
 }
 
--- Price response
--- Sent after an outgoing price request for an NPC vendor (0x085)
+-- Price/sale response
+-- Sent in response to an outgoing price request for an NPC vendor (0x085), and in response to player finalizing a sale.
+-- Inventory bag is assumed to be regular Inventory (0)
 fields.incoming[0x03D] = L{
     {ctype='unsigned int',      label='Price',              fn=gil},            -- 04
     {ctype='unsigned char',     label='Inventory Index',    fn=invp+{0x09}},    -- 08
-    {ctype='unsigned char',     label='Bag',                fn=bag},            -- 09
+    {ctype='unsigned char',     label='Type'},                                  -- 09 0 = on apprasial, 1 = when sale is finalized
     {ctype='unsigned short',    label='_junk1'},                                -- 0A
     {ctype='unsigned int',      label='_unknown1',          const=1},           -- 0C
 }

--- a/addons/libs/packets/fields.lua
+++ b/addons/libs/packets/fields.lua
@@ -2139,7 +2139,7 @@ fields.incoming[0x03D] = L{
     {ctype='unsigned char',     label='Inventory Index',    fn=inv+{0}},        -- 08
     {ctype='unsigned char',     label='Type'},                                  -- 09 0 = on price check, 1 = when sale is finalized
     {ctype='unsigned short',    label='_junk1'},                                -- 0A
-    {ctype='unsigned int',      label='Quantity Sold',      const=1},           -- 0C Will be 1 on price check
+    {ctype='unsigned int',      label='Count',      const=1},                   -- 0C Will be 1 on price check
 }
 
 -- Open Buy/Sell

--- a/addons/libs/packets/fields.lua
+++ b/addons/libs/packets/fields.lua
@@ -2134,13 +2134,12 @@ fields.incoming[0x03C] = L{
 
 -- Price/sale response
 -- Sent in response to an outgoing price request for an NPC vendor (0x085), and in response to player finalizing a sale.
--- Inventory bag is assumed to be regular Inventory (0)
 fields.incoming[0x03D] = L{
     {ctype='unsigned int',      label='Price',              fn=gil},            -- 04
     {ctype='unsigned char',     label='Inventory Index',    fn=invp+{0x09}},    -- 08
-    {ctype='unsigned char',     label='Type'},                                  -- 09 0 = on apprasial, 1 = when sale is finalized
+    {ctype='unsigned char',     label='Type'},                                  -- 09 0 = on price check, 1 = when sale is finalized
     {ctype='unsigned short',    label='_junk1'},                                -- 0A
-    {ctype='unsigned int',      label='_unknown1',          const=1},           -- 0C
+    {ctype='unsigned int',      label='Quantity Sold',      const=1},           -- 0C Will be 1 on price check
 }
 
 -- Open Buy/Sell

--- a/addons/libs/packets/fields.lua
+++ b/addons/libs/packets/fields.lua
@@ -2136,7 +2136,7 @@ fields.incoming[0x03C] = L{
 -- Sent in response to an outgoing price request for an NPC vendor (0x085), and in response to player finalizing a sale.
 fields.incoming[0x03D] = L{
     {ctype='unsigned int',      label='Price',              fn=gil},            -- 04
-    {ctype='unsigned char',     label='Inventory Index',    fn=invp+{0x09}},    -- 08
+    {ctype='unsigned char',     label='Inventory Index',    fn=inv+{0}},        -- 08
     {ctype='unsigned char',     label='Type'},                                  -- 09 0 = on price check, 1 = when sale is finalized
     {ctype='unsigned short',    label='_junk1'},                                -- 0A
     {ctype='unsigned int',      label='Quantity Sold',      const=1},           -- 0C Will be 1 on price check

--- a/addons/libs/packets/fields.lua
+++ b/addons/libs/packets/fields.lua
@@ -2139,7 +2139,7 @@ fields.incoming[0x03D] = L{
     {ctype='unsigned char',     label='Inventory Index',    fn=inv+{0}},        -- 08
     {ctype='unsigned char',     label='Type'},                                  -- 09 0 = on price check, 1 = when sale is finalized
     {ctype='unsigned short',    label='_junk1'},                                -- 0A
-    {ctype='unsigned int',      label='Count',      const=1},                   -- 0C Will be 1 on price check
+    {ctype='unsigned int',      label='Count'},                                 -- 0C Will be 1 on price check
 }
 
 -- Open Buy/Sell


### PR DESCRIPTION
Just going to quote what I said on Discord~

> I suspect the 'Bag' value might really be a flag indicating to the client if the incoming "price response" packet is either an appraisal or a sale.
> 
> I had an addon that would listen for the packet and spit the price to chatlog / filelog: https://github.com/ibm2431/addons/blob/56905074b1f0b13ada3f9fa6c1d01ef7387f8c76/pricelog/pricelog.lua#L194-L210 
> 
> And it was triggering both on the initial price request (with the correct item name from the player's current Inventory), and then later on the sale, but with an item name from the player's Mog Safe

Basically, I think SE uses the packet for double-duty:
0: To send the appraisal price to the client
1: To send the "you sell a(n) <item> to the shop" message