### PR TITLE
Use Correct URL Encoding

### DIFF
--- a/addons/linker/linker.lua
+++ b/addons/linker/linker.lua
@@ -1,5 +1,5 @@
 require('luau')
-url = require("socket.url")
+local url = require('socket.url')
 
 _addon.name = 'Linker'
 _addon.author = 'Arcon'

--- a/addons/linker/linker.lua
+++ b/addons/linker/linker.lua
@@ -1,4 +1,5 @@
 require('luau')
+url = require("socket.url")
 
 _addon.name = 'Linker'
 _addon.author = 'Arcon'
@@ -53,7 +54,7 @@ windower.register_event('addon command', function(command, ...)
     if not ... or not settings.search[command] and settings.raw[command] then
         windower.open_url(settings.raw[command])
     elseif settings.search[command] then
-        windower.open_url((settings.search[command]:gsub('${query}', L{...}:concat(' '))))
+        windower.open_url((settings.search[command]:gsub('${query}', url.escape(L{...}:concat(' ')):gsub('%%','%%%%'))))
     else
         error('Command "' .. command .. '" not found.')
     end


### PR DESCRIPTION
Added proper URL Encoding so that things like:
`//web bg Apogee Crown +1`
results in proper links such as
https://www.ffxiah.com/search/item?q=apogee%20crown%20%2b1
instead of improper things like
https://www.ffxiah.com/search/item?q=apogee%20crown%20+1