### PR TITLE
Fix parry pronoun in battlemod

### DIFF
--- a/addons/battlemod/parse_action_packet.lua
+++ b/addons/battlemod/parse_action_packet.lua
@@ -227,9 +227,9 @@ function parse_action_packet(act)
                 if m.fields.status then numb = m.status else numb = pref_suf((m.cparam or m.param),m.message) end
     
                 if msg and m.message == 70 and not simplify then -- fix pronoun on parry
-                    if act.actor.race == 0 then
+                    if v.target[1].race == 0 then
                         msg = msg:gsub(' his ',' its ')
-                    elseif female_races:contains(act.actor.race) then
+                    elseif female_races:contains(v.target[1].race) then
                         msg = msg:gsub(' his ',' her ')
                     end
                 end


### PR DESCRIPTION
Changed race check from actor to target to prevent players from being "it"s.
Before:
![its-weapon](https://user-images.githubusercontent.com/1747598/65354087-7de7b480-dba3-11e9-9f44-571b23c96780.jpg)
After:
![his-weapon](https://user-images.githubusercontent.com/1747598/65354092-7fb17800-dba3-11e9-8885-580424dcd3c6.jpg)

