### PR TITLE
battlemod: handle debuff application messages

### DIFF
--- a/addons/battlemod/parse_action_packet.lua
+++ b/addons/battlemod/parse_action_packet.lua
@@ -193,6 +193,26 @@ function parse_action_packet(act)
                 else m.simp_name = act.action.name or ''
                 end
 
+                -- Debuff Application Messages
+                if message_map[82]:contains(m.message) then
+                    if m.status == 'Evasion Down' then
+                        m.message = 237
+                    end
+                    if m.status == 'addle' then m.status = 'addled'
+                    elseif m.status == 'bind' then m.status = 'bound'
+                    elseif m.status == 'blindness' then m.status = 'blinded'
+                    elseif m.status == 'Inundation' then m.status = 'inundated'
+                    elseif m.status == 'paralysis' then m.status = 'paralyzed'
+                    elseif m.status == 'petrification' then m.status = 'petrified'
+                    elseif m.status == 'poison' then m.status = 'poisoned'
+                    elseif m.status == 'silence' then m.status = 'silenced'
+                    elseif m.status == 'sleep' then m.status = 'asleep'
+                    elseif m.status == 'slow' then m.status = 'slowed'
+                    elseif m.status == 'stun' then m.status = 'stunned'
+                    elseif m.status == 'weight' then m.status = 'weighed down'
+                    end
+                end
+
 --                if m.message == 93 or m.message == 273 then m.status=color_it('Vanish',color_arr['statuscol']) end
 
                 -- Special Message Handling


### PR DESCRIPTION
Handling for some common debuff application messages to read more fluently. Some others exist as well.

Examples:
no battlemod
![petrify-1](https://user-images.githubusercontent.com/1747598/65362517-87314b00-dbbc-11e9-9b9a-73686e3e0625.jpg)

existing battlemod
![petrify-2](https://user-images.githubusercontent.com/1747598/65362518-88fb0e80-dbbc-11e9-84ba-e9729402de65.jpg)

with this change
![petrify-3](https://user-images.githubusercontent.com/1747598/65362523-8b5d6880-dbbc-11e9-9836-4f0b5d86ef01.jpg)
