### PR TITLE
Gearswap: Filter enchanted items with duplicate names.

### DIFF
--- a/addons/GearSwap/gearswap.lua
+++ b/addons/GearSwap/gearswap.lua
@@ -25,7 +25,7 @@
 --SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 _addon.name = 'GearSwap'
-_addon.version = '0.934'
+_addon.version = '0.935'
 _addon.author = 'Byrth'
 _addon.commands = {'gs','gearswap'}
 

--- a/addons/GearSwap/statics.lua
+++ b/addons/GearSwap/statics.lua
@@ -99,7 +99,9 @@ end
 
 for i,v in pairs(res.items) do
     v.prefix = '/item'
-    make_entry(v,i)
+    if not validabils['english'][v.prefix][v.english:lower()] or v.cast_delay then
+        make_entry(v,i)
+    end
 end
     
     -- Should transition these slot maps to be based off res.slots, but it's very unlikely to change.

--- a/addons/GearSwap/version_history.txt
+++ b/addons/GearSwap/version_history.txt
@@ -1,5 +1,6 @@
 -------------------------------------------------
-
+GearSwap 0.935 - Filter enchanted items with duplicate names.
+-------------------------------------------------
 GearSwap 0.934 - Fixed /item command handling.
 -------------------------------------------------
 GearSwap 0.933 - Adjusted how item use packets are chosen. 


### PR DESCRIPTION
This addresses https://github.com/Byrth/Lua-Byrth/issues/455