### PR TITLE
add sub command 'wearable' to 'gs export'

### DIFF
--- a/addons/GearSwap/README.md
+++ b/addons/GearSwap/README.md
@@ -26,7 +26,7 @@ Commands (<> indicates a field. You do not actually have to use <>s):
 ** APPDATA/Windower/GearSwap/<string>
 ** ..Windower/addons/libs/<string>
 * gs reload : Reloads the current user file.
-* gs export <options> : Exports your currently equipped gear, inventory, or all the items in your current Lua files' sets into GearSwap .lua or spellcast .xml format. Takes options "inventory", "sets", and "xml." Defaults to currently equipped gear and lua otherwise. Also exports appropriate advanced set tables with augments for currently equipped gear and inventory.
+* gs export <options> : Exports your currently equipped gear, inventory, or all the items in your current Lua files' sets into GearSwap .lua or spellcast .xml format. Takes options "inventory", "all", "wearable", "sets", and "xml." Defaults to currently equipped gear and lua otherwise. Also exports appropriate advanced set tables with augments for currently equipped gear and inventory.
 * gs enable <slot> : Enables equip commands targeting a specified slot. "All" will allow all equip commands. Providing no slot argument will enable user GearSwap file execution, if it was disabled.
 * gs disable <slot> : Disables equip commands targeting a given slot. "All" will prevent all equip commands. Providing no second argument will disable user GearSwap file execution, although registered events will still run.
 * gs validate <sets|inv> <filter> : This command checks to see whether the equipment in the sets table also exists in your inventory (default), or (by passing "inv") whether the equipment in your inventory exists in your sets table. <filter> is an optional list of words that restricts the output to only those items that contain text from one of the filter's words.

--- a/addons/GearSwap/export.lua
+++ b/addons/GearSwap/export.lua
@@ -33,6 +33,8 @@ function export_set(options)
                 targinv = true
             elseif v:lower() == 'all' then
                 all_items = true
+            elseif v:lower() == 'wearable' then
+                wearable = true
             elseif S{'xml'}:contains(v:lower()) then
                 xml = true
             elseif S{'sets','set','s'}:contains(v:lower()) then
@@ -60,6 +62,8 @@ function export_set(options)
     local buildmsg = 'Exporting '
     if all_items then
         buildmsg = buildmsg..'all your items'
+    elseif wearable then
+        buildmsg = buildmsg..'all your items in inventory and wardrobes'
     elseif targinv then
         buildmsg = buildmsg..'your current inventory'
     elseif all_sets then
@@ -95,6 +99,10 @@ function export_set(options)
     if all_items then
         for i = 0, #res.bags do
             item_list:extend(get_item_list(items[res.bags[i].english:gsub(' ', ''):lower()]))
+        end
+    elseif wearable then
+        for _, v in pairs(equippable_item_bags) do
+            item_list:extend(get_item_list(items[v.english:gsub(' ', ''):lower()]))
         end
     elseif targinv then
         item_list:extend(get_item_list(items.inventory))


### PR DESCRIPTION
`gs export wearable` exports all items in inventory and wardrobes. Since `gs export all` export really all items that you don't use, so this subcommand is useful to storage version management and validation by another programs.

I use this for find items that is not used in my all jobs. For this purpose, `gs validate` is not suitable because necessary to look all job's sets.