### PR TITLE
Azure sets update to allow for subjob use

### DIFF
--- a/addons/azureSets/Readme.md
+++ b/addons/azureSets/Readme.md
@@ -1,5 +1,5 @@
 **Author:** Ricky Gall  
-**Version:** 1.24
+**Version:** 1.25
 **Description:**  
 Addon to make setting blue spells easier. Currently only works as blu main.
 
@@ -21,6 +21,10 @@ Addon to make setting blue spells easier. Currently only works as blu main.
  9. //aset help --Shows this menu.
 
 **Changes:**  
+v1.24 - v1.25
+ * Added ability to use AzureSets when sub blue mage.
+ * Added additional error checking around blue magic points, slots, and level requirements. 
+
 v1.23 - v1.24
  * Changed default spellset method to preserve traits.
  * Added setting for setmethod to either PresereTraits or ClearFirst.

--- a/addons/azureSets/Readme.md
+++ b/addons/azureSets/Readme.md
@@ -1,7 +1,7 @@
 **Author:** Ricky Gall  
 **Version:** 1.25
 **Description:**  
-Addon to make setting blue spells easier. Currently only works as blu main.
+Addon to make setting blue spells easier.
 
 **Abbreviations:** aset, azureset
 

--- a/addons/azureSets/azuresets.lua
+++ b/addons/azureSets/azuresets.lua
@@ -28,19 +28,19 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
 _addon.name = 'AzureSets'
-_addon.version = '1.23'
+_addon.version = '1.25'
 _addon.author = 'Nitrous (Shiva)'
-_addon.commands = {'aset','azuresets','asets'}
+_addon.commands = {'aset', 'azuresets', 'asets'}
 
 require('tables')
 require('strings')
 require('logger')
-config = require('config')
-files = require('files')
-res = require('resources')
-chat = require('chat')
+local config = require('config')
+local res = require('resources')
+local chat = require('chat')
+local spells = res.spells:type('BlueMagic')
 
-defaults = {}
+local defaults = {}
 defaults.setmode = 'PreserveTraits'
 defaults.setspeed = 0.65
 defaults.spellsets = {}
@@ -57,22 +57,62 @@ slot09='Blank Gaze', slot10='Radiant Breath', slot11='Light of Penance', slot12=
 slot13='Death Ray', slot14='Eyes On Me', slot15='Sandspray'
 }
 
-settings = config.load(defaults)
+local settings = config.load(defaults)
+local BLU_JOB_ID = 16
+
+local currentSpellSet = nil
+local bluJobLevel = nil
+local bluPointsMax = nil
+local bluSlots = nil
+local get_blu_job_data = nil
 
 function initialize()
-    spells = res.spells:type('BlueMagic')
-    get_current_spellset()
+    update_blu_info()
+    update_current_spellset()
 end
 
 windower.register_event('load', initialize:cond(function() return windower.ffxi.get_info().logged_in end))
 
-windower.register_event('login', initialize)
+windower.register_event('login', function() coroutine.schedule(initialize, 5) end)
 
-windower.register_event('job change', initialize:cond(function(job) return job == 16 end))
+windower.register_event('job change', initialize)
+
+function update_blu_info(player)
+    player = player or windower.ffxi.get_player()
+    if player.main_job_id == BLU_JOB_ID then
+        bluJobLevel = player.main_job_level
+
+        if player.main_job_level > 70 then
+            bluSlots = 20
+        else
+            bluSlots = (math.floor((player.sub_job_level + 9) / 10) * 2) + 4
+        end
+        
+        bluPointsMax = (math.floor((player.main_job_level + 9) / 10) * 5) + 5
+        if player.main_job_level >= 75 then
+            bluPointsMax = bluPointsMax + player.merits.assimilation
+            if player.main_job_level == 99 then
+                bluPointsMax = bluPointsMax + player.job_points.blu.blue_magic_point_bonus
+            end
+        end
+
+        get_blu_job_data = windower.ffxi.get_mjob_data
+    elseif player.sub_job_id == BLU_JOB_ID then
+        bluJobLevel = player.sub_job_level
+        bluSlots = (math.floor((player.sub_job_level + 9) / 10) * 2) + 4
+        bluPointsMax = (math.floor((player.sub_job_level + 9) / 10) * 5) + 5
+        get_blu_job_data = windower.ffxi.get_sjob_data
+    else
+        bluJobLevel = nil
+        bluSlots = nil
+        bluPointsMax = nil
+        get_blu_job_data = nil
+    end
+end
 
 function set_spells(spellset, setmode)
-    if windower.ffxi.get_player()['main_job_id'] ~= 16 --[[and windower.ffxi.get_player()['sub_job_id'] ~= 16]] then
-        error('Main job not set to Blue Mage.')
+    if not bluJobLevel then
+        error('You are not a Blue Mage.')
         return
     end
     if settings.spellsets[spellset] == nil then
@@ -96,22 +136,21 @@ function set_spells(spellset, setmode)
 end
 
 function is_spellset_equipped(spellset)
-    return S(spellset):map(string.lower) == S(get_current_spellset())
+    return S(spellset):map(string.lower) == S(update_current_spellset())
 end
 
 function set_spells_from_spellset(spellset, setPhase)
     local setToSet = settings.spellsets[spellset]
-    local currentSet = get_current_spellset()
+    update_current_spellset()
 
     if setPhase == 'remove' then
         -- Remove Phase
-        for k,v in pairs(currentSet) do
+        for k, v in pairs(currentSpellSet) do
             if not setToSet:contains(v:lower()) then
                 setSlot = k
                 local slotToRemove = tonumber(k:sub(5, k:len()))
 
                 windower.ffxi.remove_blue_magic_spell(slotToRemove)
-                --log('Removed spell: '..v..' at #'..slotToRemove)
                 set_spells_from_spellset:schedule(settings.setspeed, spellset, 'remove')
                 return
             end
@@ -122,7 +161,7 @@ function set_spells_from_spellset(spellset, setPhase)
     local slotToSetTo
     for i = 1, 20 do
         local slotName = 'slot%02u':format(i)
-        if currentSet[slotName] == nil then
+        if currentSpellSet[slotName] == nil then
             slotToSetTo = i
             break
         end
@@ -130,14 +169,15 @@ function set_spells_from_spellset(spellset, setPhase)
 
     if slotToSetTo ~= nil then
         -- We found an empty slot. Find a spell to set.
-        for k,v in pairs(setToSet) do
-            if not currentSet:contains(v:lower()) then
+        for k, v in pairs(setToSet) do
+            if not currentSpellSet:contains(v:lower()) then
                 if v ~= nil then
                     local spellID = find_spell_id_by_name(v)
                     if spellID ~= nil then
-                        windower.ffxi.set_blue_magic_spell(spellID, tonumber(slotToSetTo))
-                        --log('Set spell: '..v..' ('..spellID..') at: '..slotToSetTo)
-                        set_spells_from_spellset:schedule(settings.setspeed, spellset, 'add')
+                        local verified = verify_and_set_spell(spellID, tonumber(slotToSetTo))
+                        if verified then
+                            set_spells_from_spellset:schedule(settings.setspeed, spellset, 'add')
+                        end
                         return
                     end
                 end
@@ -159,39 +199,42 @@ function find_spell_id_by_name(spellname)
     return nil
 end
 
-function set_single_spell(setspell,slot)
-    if windower.ffxi.get_player()['main_job_id'] ~= 16 --[[and windower.ffxi.get_player()['sub_job_id'] ~= 16]] then return nil end
+function set_single_spell(setspell, slot)
+    if not bluJobLevel then return nil end
 
-    local tmpTable = T(get_current_spellset())
-    for key,val in pairs(tmpTable) do
-        if tmpTable[key]:lower() == setspell then
+    update_current_spellset()
+    for key, val in pairs(currentSpellSet) do
+        if currentSpellSet[key]:lower() == setspell then
             error('That spell is already set.')
             return
         end
     end
     if tonumber(slot) < 10 then slot = '0'..slot end
     --insert spell add code here
-    for spell in spells:it() do
-        if spell['english']:lower() == setspell then
-            --This is where single spell setting code goes.
-            --Need to set by spell id rather than name.
-            windower.ffxi.set_blue_magic_spell(spell['id'], tonumber(slot))
+    local spellId = find_spell_id_by_name(setspell)
+    if spellId then
+        local verified = verify_and_set_spell(spellId, tonumber(slot))
+        if verified then
             windower.send_command('@timers c "Blue Magic Cooldown" 60 up')
-            tmpTable['slot'..slot] = setspell
+            currentSpellSet['slot'..slot] = setspell
         end
     end
-    tmpTable = nil
 end
 
-function get_current_spellset()
-    if windower.ffxi.get_player().main_job_id ~= 16 then return nil end
-    return T(windower.ffxi.get_mjob_data().spells)
+function update_current_spellset(player)
+    if not get_blu_job_data then
+        currentSpellSet = nil
+        return nil
+    end
+
+    currentSpellSet = T(get_blu_job_data().spells)
     -- Returns all values but 512
     :filter(function(id) return id ~= 512 end)
     -- Transforms them from IDs to lowercase English names
     :map(function(id) return spells[id].english:lower() end)
     -- Transform the keys from numeric x or xx to string 'slot0x' or 'slotxx'
     :key_map(function(slot) return 'slot%02u':format(slot) end)
+    return currentSpellSet
 end
 
 function remove_all_spells(trigger)
@@ -204,8 +247,8 @@ function save_set(setname)
         error('Please choose a name other than default.')
         return
     end
-    local curSpells = T(get_current_spellset())
-    settings.spellsets[setname] = curSpells
+    update_current_spellset()
+    settings.spellsets[setname] = currentSpellSet
     settings:save('all')
     notice('Set '..setname..' saved.')
 end
@@ -238,21 +281,66 @@ function get_spellset_content(spellset)
     settings.spellsets[spellset]:print()
 end
 
+function verify_and_set_spell(id, slot)
+    local spell = spells[id]
+    local errorMessage = nil
+    if not spell then
+        errorMessage = "spell not found"
+    end
+    if bluJobLevel and spell.levels and spell.levels[BLU_JOB_ID] and spell.levels[BLU_JOB_ID] > bluJobLevel then
+        errorMessage = "job level too low to set spell"
+    end
+    if not have_enough_points_to_add_spell(id) then
+        errorMessage = "cannot set spell, ran out of blue magic points"
+    end
+    if slot > bluSlots then
+        errorMessage = "slot " .. tostring(slot) .. " unavailable"
+    end
+
+    if errorMessage then
+        error(errorMessage)
+        return false
+    end
+
+    windower.ffxi.set_blue_magic_spell(id, slot)
+    return true
+end
+
+function have_enough_points_to_add_spell(spellId)
+    local spell = spells[spellId]
+    if not spell or not spell.blu_points then
+        return nil
+    end
+    return spell.blu_points + current_total_points_spent() <= bluPointsMax
+end
+
+function current_total_points_spent()
+    local total = 0
+    for _, spellId in pairs(get_blu_job_data().spells) do
+        local spell = spells[spellId]
+        if spell and spell.blu_points then
+            total = total + spell.blu_points
+        end
+    end
+    return total
+end
+
 windower.register_event('addon command', function(...)
-    if windower.ffxi.get_player()['main_job_id'] ~= 16 --[[and windower.ffxi.get_player()['sub_job_id'] ~= 16]] then
-        error('You are not on (main) Blue Mage.')
+    initialize()
+    if not bluJobLevel then
+        error('You are not a Blue Mage.')
         return nil
     end
     local args = T{...}
     if args ~= nil then
-        local comm = table.remove(args,1):lower()
+        local comm = table.remove(args, 1):lower()
         if comm == 'removeall' then
             remove_all_spells('trigger')
         elseif comm == 'add' then
             if args[2] ~= nil then
-                local slot = table.remove(args,1)
+                local slot = table.remove(args, 1)
                 local spell = args:sconcat()
-                set_single_spell(spell:lower(),slot)
+                set_single_spell(spell:lower(), slot)
             end
         elseif comm == 'save' then
             if args[1] ~= nil then
@@ -267,7 +355,7 @@ windower.register_event('addon command', function(...)
                 set_spells(args[1], args[2] or settings.setmode)
             end
         elseif comm == 'currentlist' then
-            get_current_spellset():print()
+            update_current_spellset():print()
         elseif comm == 'setlist' then
             get_spellset_list()
         elseif comm == 'spelllist' then
@@ -276,20 +364,20 @@ windower.register_event('addon command', function(...)
             end
         elseif comm == 'help' then
             local helptext = [[AzureSets - Command List:')
-            1. removeall - Unsets all spells.
-            2. spellset <setname> [ClearFirst|PreserveTraits] -- Set (setname)'s spells,
-                             optional parameter: ClearFirst or PreserveTraits: overrides
-                             setting to clear spells first or remove individually,
-                             preserving traits where possible. Default: use settings or
-                             preservetraits if settings not configured.
-            3. set <setname> (clearfirst|preservetraits) -- Same as spellset
-            4. add <slot> <spell> -- Set (spell) to slot (slot (number)).
-            5. save <setname> -- Saves current spellset as (setname).
-            6. delete <setname> -- Delete (setname) spellset.
-            7. currentlist -- Lists currently set spells.
-            8. setlist -- Lists all spellsets.
-            9. spelllist <setname> -- List spells in (setname)
-            10. help --Shows this menu.]]
+1. removeall - Unsets all spells.
+2. spellset <setname> [ClearFirst|PreserveTraits] -- Set (setname)'s spells,
+    optional parameter: ClearFirst or PreserveTraits: overrides
+    setting to clear spells first or remove individually,
+    preserving traits where possible. Default: use settings or
+    preservetraits if settings not configured.
+3. set <setname> (clearfirst|preservetraits) -- Same as spellset
+4. add <slot> <spell> -- Set (spell) to slot (slot (number)).
+5. save <setname> -- Saves current spellset as (setname).
+6. delete <setname> -- Delete (setname) spellset.
+7. currentlist -- Lists currently set spells.
+8. setlist -- Lists all spellsets.
+9. spelllist <setname> -- List spells in (setname)
+10. help --Shows this menu.]]
             for _, line in ipairs(helptext:split('\n')) do
                 windower.add_to_chat(207, line..chat.controls.reset)
             end

--- a/addons/azureSets/azuresets.lua
+++ b/addons/azureSets/azuresets.lua
@@ -68,7 +68,9 @@ local language = windower.ffxi.get_info().language:lower()
 
 local spellsLookup = {}
 for spell in spells:it() do
-    spellsLookup[spell[language]:lower()] = spell
+    spellsLookup[spell.english] = spell
+    spellsLookup[spell.english:lower()] = spell
+    spellsLookup[spell.japanese] = spell
 end
 
 function initialize()
@@ -89,16 +91,16 @@ function update_blu_info(player)
     if player.main_job_id == BLU_JOB_ID then
         bluJobLevel = player.main_job_level
 
-        if player.main_job_level > 70 then
+        if bluJobLevel > 70 then
             bluSlots = 20
         else
-            bluSlots = (math.floor((player.sub_job_level + 9) / 10) * 2) + 4
+            bluSlots = (math.floor((bluJobLevel + 9) / 10) * 2) + 4
         end
         
-        bluPointsMax = (math.floor((player.main_job_level + 9) / 10) * 5) + 5
-        if player.main_job_level >= 75 then
+        bluPointsMax = (math.floor((bluJobLevel + 9) / 10) * 5) + 5
+        if bluJobLevel >= 75 then
             bluPointsMax = bluPointsMax + player.merits.assimilation
-            if player.main_job_level == 99 then
+            if bluJobLevel == 99 then
                 bluPointsMax = bluPointsMax + player.job_points.blu.blue_magic_point_bonus
             end
         end
@@ -106,8 +108,8 @@ function update_blu_info(player)
         get_blu_job_data = windower.ffxi.get_mjob_data
     elseif player.sub_job_id == BLU_JOB_ID then
         bluJobLevel = player.sub_job_level
-        bluSlots = (math.floor((player.sub_job_level + 9) / 10) * 2) + 4
-        bluPointsMax = (math.floor((player.sub_job_level + 9) / 10) * 5) + 5
+        bluSlots = (math.floor((bluJobLevel + 9) / 10) * 2) + 4
+        bluPointsMax = (math.floor((bluJobLevel + 9) / 10) * 5) + 5
         get_blu_job_data = windower.ffxi.get_sjob_data
     else
         bluJobLevel = nil
@@ -278,19 +280,19 @@ end
 function verify_and_set_spell(id, slot)
     local spell = spells[id]
     if not spell then
-        error('spell not found')
+        error('Spell named not found')
         return false
     end
     if bluJobLevel and spell.levels and spell.levels[BLU_JOB_ID] and spell.levels[BLU_JOB_ID] > bluJobLevel then
-        error('job level too low to set spell')
+        error('Blue Mage Level too low to set spell')
         return false
     end
     if not have_enough_points_to_add_spell(id) then
-        error('cannot set spell, ran out of blue magic points')
+        error('Cannot set spell, ran out of blue magic points')
         return false
     end
     if slot > bluSlots then
-        error('slot ' .. tostring(slot) .. ' unavailable')
+        error('Slot ' .. tostring(slot) .. ' unavailable')
         return false
     end
 

--- a/addons/azureSets/azuresets.lua
+++ b/addons/azureSets/azuresets.lua
@@ -1,5 +1,5 @@
 --[[
-Copyright (c) 2013, Ricky Gall
+Copyright © 2013-2025, Ricky Gall
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -14,7 +14,7 @@ documentation and/or other materials provided with the distribution.
 names of its contributors may be used to endorse or promote products
 derived from this software without specific prior written permission.
 
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 'AS IS' AND
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
 ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
 WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
 DISCLAIMED. IN NO EVENT SHALL The Addon's Contributors BE LIABLE FOR ANY
@@ -44,19 +44,22 @@ defaults.setmode = 'PreserveTraits'
 defaults.setspeed = 0.65
 defaults.spellsets = {}
 defaults.spellsets.default = T{}
-defaults.spellsets.vw1 = T{slot01='Firespit', slot02='Heat Breath', slot03='Thermal Pulse', slot04='Blastbomb',
-slot05='Infrasonics', slot06='Frost Breath', slot07='Ice Break', slot08='Cold Wave',
-slot09='Sandspin', slot10='Magnetite Cloud', slot11='Cimicine Discharge', slot12='Bad Breath',
-slot13='Acrid Stream', slot14='Maelstrom', slot15='Corrosive Ooze', slot16='Cursed Sphere',
-slot17='Awful Eye'
+defaults.spellsets.vw1 = T{
+    slot01='Firespit', slot02='Heat Breath', slot03='Thermal Pulse', slot04='Blastbomb',
+    slot05='Infrasonics', slot06='Frost Breath', slot07='Ice Break', slot08='Cold Wave',
+    slot09='Sandspin', slot10='Magnetite Cloud', slot11='Cimicine Discharge', slot12='Bad Breath',
+    slot13='Acrid Stream', slot14='Maelstrom', slot15='Corrosive Ooze', slot16='Cursed Sphere',
+    slot17='Awful Eye'
 }
-defaults.spellsets.vw2 = T{slot01='Hecatomb Wave', slot02='Mysterious Light', slot03='Leafstorm', slot04='Reaving Wind',
-slot05='Temporal Shift', slot06='Mind Blast', slot07='Blitzstrahl', slot08='Charged Whisker',
-slot09='Blank Gaze', slot10='Radiant Breath', slot11='Light of Penance', slot12='Actinic Burst',
-slot13='Death Ray', slot14='Eyes On Me', slot15='Sandspray'
+defaults.spellsets.vw2 = T{
+    slot01='Hecatomb Wave', slot02='Mysterious Light', slot03='Leafstorm', slot04='Reaving Wind',
+    slot05='Temporal Shift', slot06='Mind Blast', slot07='Blitzstrahl', slot08='Charged Whisker',
+    slot09='Blank Gaze', slot10='Radiant Breath', slot11='Light of Penance', slot12='Actinic Burst',
+    slot13='Death Ray', slot14='Eyes On Me', slot15='Sandspray'
 }
 
 local settings = config.load(defaults)
+
 local BLU_JOB_ID = 16
 
 local currentSpellSet = nil
@@ -64,7 +67,6 @@ local bluJobLevel = nil
 local bluPointsMax = nil
 local bluSlots = nil
 local get_blu_job_data = nil
-local language = windower.ffxi.get_info().language:lower()
 
 local spellsLookup = {}
 for spell in spells:it() do
@@ -73,18 +75,16 @@ for spell in spells:it() do
     spellsLookup[spell.japanese] = spell
 end
 
-function initialize()
+windower.register_event('load', 'login', 'logout', 'job change', function()
     local player = windower.ffxi.get_player()
     local is_blu = player and (player.main_job_id == BLU_JOB_ID or player.sub_job_id == BLU_JOB_ID)
-    local logged_in = windower.ffxi.get_info()
+    local logged_in = windower.ffxi.get_info().logged_in
 
     if is_blu and logged_in then
         update_blu_info()
         update_current_spellset()
     end
-end
-
-windower.register_event('load', 'login', 'job change', initialize)
+end)
 
 function update_blu_info(player)
     player = player or windower.ffxi.get_player()
@@ -96,7 +96,7 @@ function update_blu_info(player)
         else
             bluSlots = (math.floor((bluJobLevel + 9) / 10) * 2) + 4
         end
-        
+
         bluPointsMax = (math.floor((bluJobLevel + 9) / 10) * 5) + 5
         if bluJobLevel >= 75 then
             bluPointsMax = bluPointsMax + player.merits.assimilation
@@ -108,8 +108,8 @@ function update_blu_info(player)
         get_blu_job_data = windower.ffxi.get_mjob_data
     elseif player.sub_job_id == BLU_JOB_ID then
         bluJobLevel = player.sub_job_level
-        bluSlots = (math.floor((bluJobLevel + 9) / 10) * 2) + 4
-        bluPointsMax = (math.floor((bluJobLevel + 9) / 10) * 5) + 5
+        bluSlots = math.floor((bluJobLevel + 9) / 10) * 2 + 4
+        bluPointsMax = math.floor((bluJobLevel + 9) / 10) * 5 + 5
         get_blu_job_data = windower.ffxi.get_sjob_data
     else
         bluJobLevel = nil
@@ -165,6 +165,7 @@ function set_spells_from_spellset(spellset, setPhase)
             end
         end
     end
+
     -- Did not find spell to remove. Start set phase
     -- Find empty slot:
     local slotToSetTo
@@ -212,24 +213,28 @@ function set_single_spell(setspell, slot)
             return
         end
     end
-    if tonumber(slot) < 10 then slot = '0'..slot end
+
+    if tonumber(slot) < 10 then
+        slot = '0'..slot
+    end
+
     --insert spell add code here
     local spellId = find_spell_id_by_name(setspell)
     local verified = verify_and_set_spell(spellId, tonumber(slot))
     if verified then
-        windower.send_command('@timers c "Blue Magic Cooldown" 60 up')
+        windower.send_command('timers c "Blue Magic Cooldown" 60 up')
         currentSpellSet['slot'..slot] = setspell
     end
 end
 
 function update_current_spellset(player)
     currentSpellSet = T(get_blu_job_data().spells)
-    -- Returns all values but 512
-    :filter(function(id) return id ~= 512 end)
-    -- Transforms them from IDs to lowercase names
-    :map(function(id) return spells[id].name:lower() end)
-    -- Transform the keys from numeric x or xx to string 'slot0x' or 'slotxx'
-    :key_map(function(slot) return 'slot%02u':format(slot) end)
+        -- Returns all values but 512
+        :filter(function(id) return id ~= 512 end)
+        -- Transforms them from IDs to lowercase names
+        :map(function(id) return spells[id].name:lower() end)
+        -- Transform the keys from numeric x or xx to string 'slot0x' or 'slotxx'
+        :key_map(function(slot) return 'slot%02u':format(slot) end)
     return currentSpellSet
 end
 
@@ -253,7 +258,7 @@ function delete_set(setname)
     if settings.spellsets[setname] == nil then
         error('Please choose an existing spellset.')
         return
-    end    
+    end
     settings.spellsets[setname] = nil
     settings:save('all')
     notice('Deleted '..setname..'.')
@@ -319,62 +324,62 @@ function current_total_points_spent()
     return total
 end
 
-windower.register_event('addon command', function(...)
-    initialize()
+local help = function()
+    local lines = {
+        'AzureSets - Command List:',
+        '1. removeall - Unsets all spells.',
+        '2. spellset <setname> [ClearFirst|PreserveTraits] -- Set (setname)\'s spells,',
+        '    optional parameter: ClearFirst or PreserveTraits: overrides',
+        '    setting to clear spells first or remove individually,',
+        '    preserving traits where possible. Default: use settings or',
+        '    preservetraits if settings not configured.',
+        '3. set <setname> (clearfirst|preservetraits) -- Same as spellset',
+        '4. add <slot> <spell> -- Set (spell) to slot (slot (number)).',
+        '5. save <setname> -- Saves current spellset as (setname).',
+        '6. delete <setname> -- Delete (setname) spellset.',
+        '7. currentlist -- Lists currently set spells.',
+        '8. setlist -- Lists all spellsets.',
+        '9. spelllist <setname> -- List spells in (setname)',
+        '10. help --Shows this menu.',
+    }
+    for _, line in ipairs(lines) do
+        log(line)
+    end
+end
+
+windower.register_event('addon command', function(cmd, ...)
+    cmd = cmd and cmd:lower()
+    if cmd == nil or cmd == 'help' then
+        help()
+        return
+    end
+
     if not bluJobLevel then
         error('You are not a Blue Mage.')
         return nil
     end
+
     local args = T{...}
-    if args ~= nil then
-        local comm = table.remove(args, 1):lower()
-        if comm == 'removeall' then
-            remove_all_spells('trigger')
-        elseif comm == 'add' then
-            if args[2] ~= nil then
-                local slot = table.remove(args, 1)
-                local spell = args:sconcat()
-                set_single_spell(spell:lower(), slot)
-            end
-        elseif comm == 'save' then
-            if args[1] ~= nil then
-                save_set(args[1])
-            end
-        elseif comm == 'delete' then
-            if args[1] ~= nil then
-                delete_set(args[1])
-            end
-        elseif comm == 'spellset' or comm == 'set' then
-            if args[1] ~= nil then
-                set_spells(args[1], args[2] or settings.setmode)
-            end
-        elseif comm == 'currentlist' then
-            update_current_spellset():print()
-        elseif comm == 'setlist' then
-            get_spellset_list()
-        elseif comm == 'spelllist' then
-            if args[1] ~= nil then
-                get_spellset_content(args[1])
-            end
-        elseif comm == 'help' then
-            local helptext = [[AzureSets - Command List:')
-1. removeall - Unsets all spells.
-2. spellset <setname> [ClearFirst|PreserveTraits] -- Set (setname)'s spells,
-    optional parameter: ClearFirst or PreserveTraits: overrides
-    setting to clear spells first or remove individually,
-    preserving traits where possible. Default: use settings or
-    preservetraits if settings not configured.
-3. set <setname> (clearfirst|preservetraits) -- Same as spellset
-4. add <slot> <spell> -- Set (spell) to slot (slot (number)).
-5. save <setname> -- Saves current spellset as (setname).
-6. delete <setname> -- Delete (setname) spellset.
-7. currentlist -- Lists currently set spells.
-8. setlist -- Lists all spellsets.
-9. spelllist <setname> -- List spells in (setname)
-10. help --Shows this menu.]]
-            for _, line in ipairs(helptext:split('\n')) do
-                windower.add_to_chat(207, line..chat.controls.reset)
-            end
-        end
+    local argcount = select('#', ...)
+    if cmd == 'removeall' then
+        remove_all_spells('trigger')
+    elseif cmd == 'add' and argcount > 1 then
+        local slot = table.remove(args, 1)
+        local spell = args:sconcat()
+        set_single_spell(spell:lower(), slot)
+    elseif cmd == 'save' and argcount > 0 then
+        save_set(args[1])
+    elseif cmd == 'delete' and argcount > 0 then
+        delete_set(args[1])
+    elseif (cmd == 'spellset' or cmd == 'set') and argcount > 0 then
+        set_spells(args[1], args[2] or settings.setmode)
+    elseif cmd == 'currentlist' then
+        update_current_spellset():print()
+    elseif cmd == 'setlist' then
+        get_spellset_list()
+    elseif cmd == 'spelllist' and argcount > 0 then
+        get_spellset_content(args[1])
+    else
+        help()
     end
 end)


### PR DESCRIPTION
Updated the addon AzureSets to allow for use while subbing blue mage. This involved refactoring, adding a number of checks to ensure the user is on the correct job, has enough blue magic points to spend, has an open spell slot, and is of the correct level to set that spell. 