### PR TITLE
Handling the new Siren BP that does HP drain

### DIFF
--- a/addons/scoreboard/scoreboard.lua
+++ b/addons/scoreboard/scoreboard.lua
@@ -437,6 +437,9 @@ function action_handler(raw_actionpacket)
                     dps_db:incr_ws_misses(target:get_name(), create_mob_name(actionpacket))
                 elseif main.resource and main.resource == 'weapon_skills' and main.conclusion then
                     dps_db:add_ws_damage(target:get_name(), create_mob_name(actionpacket), main.param, main.spell_id)
+                -- Siren's Hysteric Assault does HP drain and falls under message_id 802
+                elseif main.message_id == 802 then
+                    dps_db:add_damage(target:get_name(), create_mob_name(actionpacket), main.param)
                 elseif main.conclusion then
                     if main.conclusion.subject == 'target' and T(main.conclusion.objects):contains('HP') and main.param ~= 0 then
                         dps_db:add_damage(target:get_name(), create_mob_name(actionpacket), (main.conclusion.verb == 'gains' and -1 or 1)*main.param)

--- a/addons/scoreboard/scoreboard.lua
+++ b/addons/scoreboard/scoreboard.lua
@@ -485,7 +485,7 @@ function find_pet_owner_name(actionpacket)
     for _, member in pairs(party) do
         if type(member) == 'table' and member.mob then
             if member.mob.pet_index and member.mob.pet_index> 0 and pet.index == member.mob.pet_index then
-				name = member.mob.name
+                name = member.mob.name
                 break
             end
         end


### PR DESCRIPTION
Siren has a new BP that does HP drain which scoreboard is currently not capturing. The ID is 802 and damage comes in as main.param.

I also removed a tab that I spotted.