### PR TITLE
EmpyPopTracker fix - items would not show green when obtained

### DIFF
--- a/addons/EmpyPopTracker/EmpyPopTracker.lua
+++ b/addons/EmpyPopTracker/EmpyPopTracker.lua
@@ -29,7 +29,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 _addon.name = 'Empy Pop Tracker'
 _addon.author = 'Dean James (Xurion of Bismarck)'
 _addon.commands = { 'ept', 'empypoptracker' }
-_addon.version = '2.1.0'
+_addon.version = '2.1.1'
 
 config = require('config')
 res = require('resources')
@@ -68,10 +68,12 @@ colors.warning = '\\cs(255,170,0)'
 colors.close = '\\cr'
 
 function owns_item(id, items)
-    for _, bag in ipairs(items) do
-        for _, item in ipairs(bag) do
-            if item.id == id then
-                return true
+    for _, bag in pairs(items) do
+        if type(bag) == 'table' then
+            for _, item in ipairs(bag) do
+                if item.id == id then
+                    return true
+                end
             end
         end
     end

--- a/addons/addons.xml
+++ b/addons/addons.xml
@@ -215,7 +215,7 @@
   <addon>
     <name>EmpyPopTracker</name>
     <author>Dean James (Xurion of Bismarck)</author>
-    <description>Tracks items and key items for popping Empyrean NMs in Abyssea, such as Briareus, Apademak and Sobek.</description>
+    <description>Tracks items and key items for popping various NMs, such as Briareus, Apademak and Warder of Courage.</description>
     <bugtracker>https://github.com/xurion/ffxi-empy-pop-tracker/issues</bugtracker>
     <support>https://www.ffxiah.com/forum/topic/54376/empyrean-pop-tracker-addon-10-years-late/</support>
   </addon>


### PR DESCRIPTION
Fixes a derp from me where the loop over the bags used ipairs and therefore did not iterate over any bags (they're referenced by name and not index). I guess I just checked KIs were turning green and not regular items 🤷‍♂ 

Also had to put a check in for the data type of the bag being a table because `get_items()` returns things like gil and max storage counts (line 72).

Updated addon description to cover non-Abyssea NMs.

https://github.com/xurion/ffxi-empy-pop-tracker/issues/5
