### PR TITLE
Add burdentracker to settings

### DIFF
--- a/addons/autocontrol/autocontrol.lua
+++ b/addons/autocontrol/autocontrol.lua
@@ -59,7 +59,8 @@ defaults.autosets.default = T{ }
 defaults.AutoActivate = true
 defaults.AutoDeusExAutomata = false
 defaults.maneuvertimers = true
-    
+defaults.burdentracker = true
+
 settings = config.load(defaults)
 
 require('maneuver') -- has to be loaded after settings are parsed.
@@ -92,7 +93,9 @@ function initialize()
         if player.pet_index then 
             running = 1
             text_update_loop('start')
-            Burden_tb:show()
+            if settings.burdentracker then
+              Burden_tb:show()
+            end
         end
     end
 end

--- a/addons/autocontrol/maneuver.lua
+++ b/addons/autocontrol/maneuver.lua
@@ -132,7 +132,9 @@ windower.register_event("action", function(act)
                 windower.send_command('@timers d Overloaded!')
                 heatupdate()
             elseif abil_ID == 136 or abil_ID == 310 then -- Activate or Deus Ex Automata
-                Burden_tb:show()
+                if settings.burdentracker then
+                  Burden_tb:show()
+                end
                 decay = get_decay()
                 activate_burden()
             elseif abil_ID == 139 then
@@ -397,7 +399,9 @@ function zone_check(to)
             if player_mob then
                 if player_mob.pet_index
                    and player_mob.pet_index ~= 0 then 
-                    Burden_tb:show()
+                     if settings.burdentracker then
+                       Burden_tb:show()
+                     end
                     activate_burden()
                 end
             else


### PR DESCRIPTION
Not sure this is the ideal way to do this...

Adds burdentracker to settings so it can default to hidden with `<burdentracker>false</burdentracker>`.

The burden tracker is still maintained so `//acon show` will restore the tracker as expected.