### PR TITLE
EmpyPopTracker 2.2.2

### DIFF
--- a/addons/EmpyPopTracker/EmpyPopTracker.lua
+++ b/addons/EmpyPopTracker/EmpyPopTracker.lua
@@ -29,7 +29,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 _addon.name = 'Empy Pop Tracker'
 _addon.author = 'Dean James (Xurion of Bismarck)'
 _addon.commands = { 'ept', 'empypoptracker' }
-_addon.version = '2.2.1'
+_addon.version = '2.2.2'
 
 config = require('config')
 res = require('resources')
@@ -70,6 +70,10 @@ defaults.colors.pool = {}
 defaults.colors.pool.red = 255
 defaults.colors.pool.green = 170
 defaults.colors.pool.blue = 0
+defaults.colors.bg = {}
+defaults.colors.bg.red = 0
+defaults.colors.bg.green = 0
+defaults.colors.bg.blue = 0
 defaults.colors.bgall = {}
 defaults.colors.bgall.red = 0
 defaults.colors.bgall.green = 75
@@ -286,7 +290,7 @@ EmpyPopTracker.update = function()
     if generated_info.has_all_pops then
         EmpyPopTracker.text:bg_color(EmpyPopTracker.settings.colors.bgall.red, EmpyPopTracker.settings.colors.bgall.green, EmpyPopTracker.settings.colors.bgall.blue)
     else
-        EmpyPopTracker.text:bg_color(EmpyPopTracker.settings.text.red, EmpyPopTracker.settings.text.green, EmpyPopTracker.settings.text.blue)
+        EmpyPopTracker.text:bg_color(EmpyPopTracker.settings.colors.bg.red, EmpyPopTracker.settings.colors.bg.green, EmpyPopTracker.settings.colors.bg.blue)
     end
     if EmpyPopTracker.settings.visible then
         EmpyPopTracker.text:visible(true)


### PR DESCRIPTION
When calling `text:bg_color(r, g, b)`, even though the settings file is not persisted automatically with the change, the settings table linked to the text box is updated. This caused an issue when trying to revert the bg colour back to the default, using `settings.text.bg.red` when the tracked NM was popped.

Added the default bg colours to settings.