### PR TITLE
NCM: Fix error on mount in non-campaign areas

### DIFF
--- a/addons/NoCampaignMusic/README.md
+++ b/addons/NoCampaignMusic/README.md
@@ -8,16 +8,6 @@ Prevents all campaign battle music from playing in Final Fantasy XI, so you can 
 //lua load ncm
 ```
 
-## Activate/deactivate
-
-```
-//ncm on
-```
-
-```
-//ncm off
-```
-
 ## Campaign notifications
 
 If you want to know when campaign is happening, you can toggle notifications:


### PR DESCRIPTION
* Completely removed the `campaign_active` variable as it was no longer used.
* Updated stale readme.