### PR TITLE
Correcting incoming 0x05A _unknown1

### DIFF
--- a/addons/libs/packets/fields.lua
+++ b/addons/libs/packets/fields.lua
@@ -2714,7 +2714,7 @@ fields.incoming[0x05A] = L{
     {ctype='unsigned short',    label='Player Index',       fn=index},          -- 0C
     {ctype='unsigned short',    label='Target Index',       fn=index},          -- 0E
     {ctype='unsigned short',    label='Emote',              fn=emote},          -- 10
-    {ctype='unsigned short',    label='_unknown1',          const=2},           -- 12
+    {ctype='unsigned short',    label='_unknown1'},                             -- 12
     {ctype='unsigned short',    label='_unknown2'},                             -- 14
     {ctype='unsigned char',     label='Type'},                                  -- 16   2 for motion, 0 otherwise
     {ctype='unsigned char',     label='_unknown3'},                             -- 17


### PR DESCRIPTION
Whatever it is, it's not a constant 2 anymore. Appears to be job -1 for /jobemotes (presumably -1 because there is no None), but for other emotes it seems to vary somewhere between 0 and 2. Possibly race/model related?