### PR TITLE
fixed images.hover

### DIFF
--- a/addons/libs/images.lua
+++ b/addons/libs/images.lua
@@ -348,15 +348,13 @@ function images.hover(t, x, y)
         return false
     end
 
-    local pos_x, pos_y = t:pos()
-    local off_x, off_y = t:get_extents()
-    
-    -- print(x, y, pos_x, pos_y, off_x, off_y)
+    local start_pos_x, start_pos_y = t:pos()
+    local end_pos_x, end_pos_y = t:get_extents()
 
-    return (pos_x <= x and x <= off_x
-        or pos_x >= x and x >= off_x)
-    and (pos_y <= y and y <= off_y
-        or pos_y >= y and y >= off_y)
+    return (start_pos_x <= x and x <= end_pos_x
+        or start_pos_x >= x and x >= end_pos_x)
+    and (start_pos_y <= y and y <= end_pos_y
+        or start_pos_y >= y and y >= end_pos_y)
 end
 
 function images.destroy(t)

--- a/addons/libs/images.lua
+++ b/addons/libs/images.lua
@@ -351,12 +351,12 @@ function images.hover(t, x, y)
     local pos_x, pos_y = t:pos()
     local off_x, off_y = t:get_extents()
     
-    -- print(pos_x, pos_y, off_x, off_y)
+    -- print(x, y, pos_x, pos_y, off_x, off_y)
 
-    return (pos_x <= x and x <= pos_x + off_x
-        or pos_x >= x and x >= pos_x + off_x)
-    and (pos_y <= y and y <= pos_y + off_y
-        or pos_y >= y and y >= pos_y + off_y)
+    return (pos_x <= x and x <= off_x
+        or pos_x >= x and x >= off_x)
+    and (pos_y <= y and y <= off_y
+        or pos_y >= y and y >= off_y)
 end
 
 function images.destroy(t)


### PR DESCRIPTION
There was an error in the bounds calculation. The right/bottom sides were compared to pos + extents. But the extents are already a combination of pos + size.
Tested this using the drag & drop functionality. Before the fix, you could drag images by clicking outside their bounds.