### PR TITLE
Fields: incoming 0x056 Type is a short

### DIFF
--- a/addons/libs/packets/fields.lua
+++ b/addons/libs/packets/fields.lua
@@ -2641,7 +2641,7 @@ fields.incoming[0x056] = function (data, type)
 end
 
 func.incoming[0x056].type = L{ 
-    {ctype='int',                label='Type',   fn=e+{'quest_mission_log'}}    -- 24
+    {ctype='short',         label='Type',       fn=e+{'quest_mission_log'}}     -- 24
 }
 
 func.incoming[0x056][0x0080] = L{


### PR DESCRIPTION
The upper 2 bytes are confirmed junk. While its always zeroed when zoning, I have been getting random values when completing quests.