### PR TITLE
misc fixes

### DIFF
--- a/addons/libs/packets/fields.lua
+++ b/addons/libs/packets/fields.lua
@@ -3408,7 +3408,7 @@ fields.incoming[0x0E0] = L{
 -- Party Member List
 fields.incoming[0x0E1] = L{
     {ctype='unsigned short',    label='Party ID'},                              -- 04 For whatever reason, this is always valid ASCII in my captured packets.
-    {ctype='unsigned short',    label='_unknown1',          const=0x0080},      -- 06  Likely contains information about the current chat mode and vote count
+    {ctype='unsigned short',    label='_unknown1',          const=0x8000},      -- 06  Likely contains information about the current chat mode and vote count
 }
 
 -- Char Info

--- a/addons/libs/xml.lua
+++ b/addons/libs/xml.lua
@@ -567,7 +567,7 @@ function table.to_xml(t, indentlevel)
         end
         if type(val) == 'table' and next(val) then
             str = str..indent..'<'..key..'>\n'
-            str = str..table.to_xml(val, indentlevel + 1)..'\n'
+            str = str..table.to_xml(val, indentlevel + 1)
             str = str..indent..'</'..key..'>\n'
         else
             if type(val) == 'table' then


### PR DESCRIPTION
fixed const size in incoming 0x0E1
fixed redundant newline in table.to_xml() function (the function already returns a newlined string, no need to add another one at the end again)