### PR TITLE
MountRoulette addon

### DIFF
--- a/addons/MountRoulette/MountRoulette.lua
+++ b/addons/MountRoulette/MountRoulette.lua
@@ -1,0 +1,79 @@
+_addon.name    = 'Mount Roulette'
+_addon.author  = 'Dean James (Xurion of Bismarck)'
+_addon.version = '3.0.0'
+_addon.commands = {'mountroulette', 'mr'}
+
+require('lists')
+resources = require('resources')
+
+math.randomseed(os.time())
+
+allowed_mounts = L{}
+possible_mounts = L{}
+for _, mount in ipairs(resources.mounts) do
+    possible_mounts:append(mount.name:lower())
+end
+
+function update_allowed_mounts()
+    local kis = windower.ffxi.get_key_items()
+
+    for _, id in ipairs(kis) do
+        local ki = resources.key_items[id]
+        if ki.category == 'Mounts' and ki.name ~= "trainer's whistle" then -- Don't care about the quest KI
+            local mount_index = possible_mounts:find(function(possible_mount)
+                return windower.wc_match(ki.name:lower(), '♪' .. possible_mount .. '*')
+            end)
+            local mount = possible_mounts[mount_index]
+
+            -- Add this to allowed mounts if it is not already there
+            if not allowed_mounts:contains(mount) then
+                allowed_mounts:append(mount)
+            end
+        end
+    end
+end
+
+windower.register_event('load', function()
+    update_allowed_mounts()
+end)
+
+windower.register_event('incoming chunk', function(id)
+    if id == 0x055 then --ki update
+        update_allowed_mounts()
+    end
+end)
+
+windower.register_event('addon command', function(command)
+    command = command and command:lower() or 'mount'
+
+    if commands[command] then
+        commands[command]()
+    else
+        commands.help()
+    end
+end)
+
+commands = {}
+
+commands.mount = function()
+    local player = windower.ffxi.get_player()
+
+    -- If the player is mounted, dismount now
+    for _, buff in pairs(player.buffs) do
+        if buff == 252 then --mounted buff
+            windower.send_command('input /dismount')
+            return
+        end
+    end
+
+    -- Generate random number and use it to choose a mount
+    local mount_index = math.ceil(math.random() * #allowed_mounts)
+    windower.send_command('input /mount ' .. allowed_mounts[mount_index])
+end
+
+commands.help = function()
+    windower.add_to_chat(8, '---Mount Roulette---')
+    windower.add_to_chat(8, 'Available commands:')
+    windower.add_to_chat(8, '//mr mount (or just //mr) - Selects a mount at random, or dismounts if mounted')
+    windower.add_to_chat(8, '//mr help - displays this help')
+end

--- a/addons/MountRoulette/MountRoulette.lua
+++ b/addons/MountRoulette/MountRoulette.lua
@@ -53,6 +53,8 @@ windower.register_event('addon command', function()
         end
     end
 
+    if #allowed_mounts == 0 then return end
+
     -- Generate random number and use it to choose a mount
     local mount_index = math.ceil(math.random() * #allowed_mounts)
     windower.send_command('input /mount ' .. allowed_mounts[mount_index])

--- a/addons/MountRoulette/README.md
+++ b/addons/MountRoulette/README.md
@@ -1,0 +1,17 @@
+# Final Fantasy XI Mount Roulette
+
+A Lua addon to summon a mount at random for Windower 4. Mimics the FFXIV Mount Roulette function.
+
+## Usage
+
+Get the addon from the addon section of the Windower launcher.
+
+### Summon a mount
+
+`//mr`
+
+This will also dismount you if you're currently mounted.
+
+## Mount music
+
+In an earlier version, this addon disabled mount music. This is now removed in favour of the MountMuzzle addon.

--- a/addons/addons.xml
+++ b/addons/addons.xml
@@ -371,6 +371,13 @@
     <support>https://discord.gg/b275nMv</support>
   </addon>
   <addon>
+    <name>MountRoulette</name>
+    <author>Dean James (Xurion of Bismarck)</author>
+    <description>Summon a mount at random, similar to Mount Roulette in FFXIV.</description>
+    <bugtracker>https://github.com/xurion/ffxi-mount-roulette/issues</bugtracker>
+    <support>https://www.ffxiah.com/forum/topic/52094/randommount-a-random-mount-selector-for-windower/</support>
+  </addon>
+  <addon>
     <name>NoCampaignMusic</name>
     <description>Prevents campaign battle music from playing in Shadowreign areas.</description>
     <author>Dean James (Xurion of Bismarck)</author>
@@ -829,5 +836,5 @@
     <description>Allows you to set a screen position per character name. Each character will be moved to that screen position on login. Requires the WinControl plugin to be installed.</description>
     <bugtracker>https://github.com/Windower/Lua/issues</bugtracker>
     <support>https://github.com/lili-ffxi</support>
-  </addon>  
+  </addon>
 </addons>


### PR DESCRIPTION
Summons a mount at random based on your mount key items.

A function to blacklist certain mounts exists on another branch and isn't included in this PR because of the impact of https://github.com/Windower/Lua/issues/1916 (blacklists mounts unexpectedly across multiple characters).