### PR TITLE
Fixed weather_intensity bug

### DIFF
--- a/addons/GearSwap/refresh.lua
+++ b/addons/GearSwap/refresh.lua
@@ -425,30 +425,21 @@ function weather_update(id)
     world.real_weather = res.weather[id][language]
     world.real_weather_element = res.elements[res.weather[id].element][language]
     world.real_weather_intensity = res.weather[world.real_weather_id].intensity
-    local buff = false
     if buffactive[178] then
-        buff = true
         world.weather_id = 4
     elseif buffactive[179] then
-        buff = true
         world.weather_id = 12
     elseif buffactive[180] then
-        buff = true
         world.weather_id = 10
     elseif buffactive[181] then
-        buff = true
         world.weather_id = 8
     elseif buffactive[182] then
-        buff = true
         world.weather_id = 14
     elseif buffactive[183] then
-        buff = true
         world.weather_id = 6
     elseif buffactive[184] then
-        buff = true
         world.weather_id = 16
     elseif buffactive[185] then
-        buff = true
         world.weather_id = 18
     elseif buffactive[589] then
         world.weather_id = 5
@@ -466,9 +457,6 @@ function weather_update(id)
         world.weather_id = 17
     elseif buffactive[596] then
         world.weather_id = 19
-    end
-    if buff and world.weather_id == world.real_weather_id then
-        world.weather_id = world.weather_id + 1
     end
     world.weather = res.weather[world.weather_id][language]
     world.weather_element = res.elements[res.weather[world.weather_id].element][language]


### PR DESCRIPTION
Removed incorrect logic that made weather_intensity return 2 (double weather) if tier 1 scholar -storm buff were active while the natural weather of the same element was active. -storm spells always overwrite natural weather no matter what.