### PR TITLE
add alternate output mode to scoreboard

### DIFF
--- a/addons/scoreboard/display.lua
+++ b/addons/scoreboard/display.lua
@@ -230,7 +230,7 @@ end
 
 -- Takes a table of elements to be wrapped across multiple lines and returns
 -- a table of strings, each of which fits within one FFXI line.
-local function wrap_elements(elements, header, sep)
+local function wrap_elements(elements, header, alt, sep)
     local max_line_length = 120 -- game constant
     if not sep then
         sep = ', '
@@ -241,31 +241,43 @@ local function wrap_elements(elements, header, sep)
     local line_length
 
     local i = 1
-    while i <= #elements do
-        if not current_line then
-            current_line = T{}
-            line_length = header:len()
-            lines:append(current_line)
+    if not alt then
+        while i <= #elements do
+            if not current_line then
+                current_line = T{}
+                line_length = header:len()
+                lines:append(current_line)
+            end
+
+            local new_line_length = line_length + elements[i]:len() + sep:len()
+            if new_line_length > max_line_length then
+                current_line = T{}
+                lines:append(current_line)
+                new_line_length = elements[i]:len() + sep:len()
+            end
+
+            current_line:append(elements[i])
+            line_length = new_line_length
+            i = i + 1
         end
-
-        local new_line_length = line_length + elements[i]:len() + sep:len()
-        if new_line_length > max_line_length then
+        local baked_lines = lines:map(function (ls) return ls:concat(sep) end)
+        if header:len() > 0 and #baked_lines > 0 then
+            baked_lines[1] = header .. baked_lines[1]
+        end
+        return baked_lines
+    else
+        header_line = T{}
+        header_line:append(header)
+        lines:append(header_line)
+        while i <= #elements do
             current_line = T{}
             lines:append(current_line)
-            new_line_length = elements[i]:len() + sep:len()
+            current_line:append(elements[i])
+            i = i + 1
         end
-
-        current_line:append(elements[i])
-        line_length = new_line_length
-        i = i + 1
+        local baked_lines = lines:map(function (ls) return ls:concat(' ') end)
+        return baked_lines
     end
-
-    local baked_lines = lines:map(function (ls) return ls:concat(sep) end)
-    if header:len() > 0 and #baked_lines > 0 then
-        baked_lines[1] = header .. baked_lines[1]
-    end
-
-    return baked_lines
 end
 
 
@@ -288,7 +300,8 @@ function Display:report_summary (...)
 
     -- Send the report to the specified chatmode
     slow_output(build_input_command(chatmode, tell_target),
-                wrap_elements(elements:slice(1, self.settings.numplayers), 'Dmg: '), self.settings.numplayers)
+                wrap_elements(elements, 'Damage: ', self.settings.alternateoutput),
+                self.settings.numplayers)
 end
 
 -- This is a table of the line aggregators and related utilities
@@ -395,7 +408,7 @@ function Display:report_stat(stat, args)
         end)
 
         -- Send the report to the specified chatmode
-        local wrapped = wrap_elements(elements:slice(1, self.settings.numplayers):map(function (p) return p[2] end), header)
+        local wrapped = wrap_elements(elements:slice(1, self.settings.numplayers):map(function (p) return p[2] end), header, self.settings.alternateoutput)
         slow_output(build_input_command(args.chatmode, args.telltarget), wrapped, self.settings.numplayers)
     end
 end
@@ -413,7 +426,7 @@ end
 return Display
 
 --[[
-Copyright © 2013-2014, Jerry Hebert
+Copyright ï¿½ 2013-2014, Jerry Hebert
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/addons/scoreboard/player.lua
+++ b/addons/scoreboard/player.lua
@@ -48,7 +48,7 @@ function Player:new (o)
     }
     attrs.name = o.name
     o = attrs
-    if o.name:match('^Skillchain%(') then
+    if o.name:match('^Skillchain%(') or o.name:match('^SC:') then
         o.is_sc = true
     else
         o.is_sc = false

--- a/addons/scoreboard/scoreboard.lua
+++ b/addons/scoreboard/scoreboard.lua
@@ -30,6 +30,7 @@ default_settings.visible = true
 default_settings.showfellow = true
 default_settings.UpdateFrequency = 0.5
 default_settings.combinepets = true
+default_settings.alternateoutput = false
 
 default_settings.display = {}
 default_settings.display.pos = {}
@@ -148,7 +149,7 @@ windower.register_event('addon command', function()
                     error("Invalid value for 'showallidps'. Must be true or false.")
                     return
                 end
-                
+
                 settings:save()
                 sb_output("Setting 'showalldps' set to " .. tostring(settings.showallidps))
             elseif setting == 'resetfilters' then
@@ -160,7 +161,7 @@ windower.register_event('addon command', function()
                     error("Invalid value for 'resetfilters'. Must be true or false.")
                     return
                 end
-                
+
                 settings:save()
                 sb_output("Setting 'resetfilters' set to " .. tostring(settings.resetfilters))
             elseif setting == 'showfellow' then
@@ -172,9 +173,20 @@ windower.register_event('addon command', function()
                     error("Invalid value for 'showfellow'. Must be true or false.")
                     return
                 end
-                
+
                 settings:save()
                 sb_output("Setting 'showfellow' set to " .. tostring(settings.showfellow))
+            elseif setting == 'alternateoutput' then
+                if params[2] == 'true' then
+                    settings.alternateoutput = true
+                elseif params[2] == 'false' then
+                    settings.alternateoutput = false
+                else
+                    error("Invalid value for 'alternateoutput'. Must be true or false.")
+                    return
+                end
+                settings:save()
+                sb_output("Setting 'alternateoutput' set to " .. tostring(settings.alternateoutput))
             end
         elseif command == 'reset' then
             reset()
@@ -448,13 +460,23 @@ function action_handler(raw_actionpacket)
                 
                 if add and add.conclusion then
                     local actor_name = create_mob_name(actionpacket)
-                    if T{196,223,288,289,290,291,292,
-                        293,294,295,296,297,298,299,
-                        300,301,302,385,386,387,388,
-                        389,390,391,392,393,394,395,
-                        396,397,398,732,767,768,769,770}:contains(add.message_id) then
-                        actor_name = string.format("Skillchain(%s%s)", actor_name:sub(1, 3),
-                                                      actor_name:len() > 3 and '.' or '')
+                    if not settings.alternateoutput then
+                        if T{196,223,288,289,290,291,292,
+                            293,294,295,296,297,298,299,
+                            300,301,302,385,386,387,388,
+                            389,390,391,392,393,394,395,
+                            396,397,398,732,767,768,769,770}:contains(add.message_id) then
+                            actor_name = string.format("Skillchain(%s%s)", actor_name:sub(1, 3),
+                                                        actor_name:len() > 3 and '.' or '')
+                        end
+                    else
+                        if T{196,223,288,289,290,291,292,
+                            293,294,295,296,297,298,299,
+                            300,301,302,385,386,387,388,
+                            389,390,391,392,393,394,395,
+                            396,397,398,732,767,768,769,770}:contains(add.message_id) then
+                            actor_name = string.format("SC:%s", actor_name:sub(1, 13))
+                        end
                     end
                     if add.conclusion.subject == 'target' and T(add.conclusion.objects):contains('HP') and add.param ~= 0 then
                         dps_db:add_damage(target:get_name(), actor_name, (add.conclusion.verb == 'gains' and -1 or 1)*add.param)
@@ -507,11 +529,19 @@ function create_mob_name(actionpacket)
             result = actor
         end
         if settings.combinepets then
-            result = 'Pets'
+            if settings.alternateoutput then
+                result = 'Pets:'
+            else
+                result = 'Pets'
+            end
         else
             result = actor
         end
-        result = result..' ('..string.sub(owner, 1, 3)..'.)'
+        if settings.alternateoutput then
+            result = result..string.sub(owner, 1, 11)
+        else
+            result = result..' ('..string.sub(owner, 1, 3)..'.)'
+        end
     else
         return actor
     end


### PR DESCRIPTION
Added an additional display mode (disabled by default, enabled with `//sb set alternateoutput true`) which minimizes pet/skillchain headers to leave more space for player names, and reports only one entity per line of output to aid legibility.

![image](https://user-images.githubusercontent.com/1747598/97797076-0a520c80-1bd7-11eb-88fd-78a7d44381bb.png)

![image](https://user-images.githubusercontent.com/1747598/97797088-2b1a6200-1bd7-11eb-8ab4-4e6bc5f28399.png)
