### PR TITLE
add alternate output mode for scoreboard

### DIFF
--- a/addons/scoreboard/display.lua
+++ b/addons/scoreboard/display.lua
@@ -230,7 +230,7 @@ end
 
 -- Takes a table of elements to be wrapped across multiple lines and returns
 -- a table of strings, each of which fits within one FFXI line.
-local function wrap_elements(elements, header, sep)
+local function wrap_elements(elements, header, alt, sep)
     local max_line_length = 120 -- game constant
     if not sep then
         sep = ', '
@@ -241,31 +241,43 @@ local function wrap_elements(elements, header, sep)
     local line_length
 
     local i = 1
-    while i <= #elements do
-        if not current_line then
-            current_line = T{}
-            line_length = header:len()
-            lines:append(current_line)
+    if not alt then
+        while i <= #elements do
+            if not current_line then
+                current_line = T{}
+                line_length = header:len()
+                lines:append(current_line)
+            end
+
+            local new_line_length = line_length + elements[i]:len() + sep:len()
+            if new_line_length > max_line_length then
+                current_line = T{}
+                lines:append(current_line)
+                new_line_length = elements[i]:len() + sep:len()
+            end
+
+            current_line:append(elements[i])
+            line_length = new_line_length
+            i = i + 1
         end
-
-        local new_line_length = line_length + elements[i]:len() + sep:len()
-        if new_line_length > max_line_length then
+        local baked_lines = lines:map(function (ls) return ls:concat(sep) end)
+        if header:len() > 0 and #baked_lines > 0 then
+            baked_lines[1] = header .. baked_lines[1]
+        end
+        return baked_lines
+    else
+        header_line = T{}
+        header_line:append(header)
+        lines:append(header_line)
+        while i <= #elements do
             current_line = T{}
             lines:append(current_line)
-            new_line_length = elements[i]:len() + sep:len()
+            current_line:append(elements[i])
+            i = i + 1
         end
-
-        current_line:append(elements[i])
-        line_length = new_line_length
-        i = i + 1
+        local baked_lines = lines:map(function (ls) return ls:concat(' ') end)
+        return baked_lines
     end
-
-    local baked_lines = lines:map(function (ls) return ls:concat(sep) end)
-    if header:len() > 0 and #baked_lines > 0 then
-        baked_lines[1] = header .. baked_lines[1]
-    end
-
-    return baked_lines
 end
 
 
@@ -288,7 +300,8 @@ function Display:report_summary (...)
 
     -- Send the report to the specified chatmode
     slow_output(build_input_command(chatmode, tell_target),
-                wrap_elements(elements:slice(1, self.settings.numplayers), 'Dmg: '), self.settings.numplayers)
+                wrap_elements(elements, 'Damage: ', self.settings.oneperline),
+                self.settings.numplayers)
 end
 
 -- This is a table of the line aggregators and related utilities
@@ -395,7 +408,7 @@ function Display:report_stat(stat, args)
         end)
 
         -- Send the report to the specified chatmode
-        local wrapped = wrap_elements(elements:slice(1, self.settings.numplayers):map(function (p) return p[2] end), header)
+        local wrapped = wrap_elements(elements:slice(1, self.settings.numplayers):map(function (p) return p[2] end), header, self.settings.oneperline)
         slow_output(build_input_command(args.chatmode, args.telltarget), wrapped, self.settings.numplayers)
     end
 end

--- a/addons/scoreboard/player.lua
+++ b/addons/scoreboard/player.lua
@@ -48,7 +48,7 @@ function Player:new (o)
     }
     attrs.name = o.name
     o = attrs
-    if o.name:match('^Skillchain%(') then
+    if o.name:match('^Skillchain%(') or o.name:match('^SC:') then
         o.is_sc = true
     else
         o.is_sc = false
@@ -148,7 +148,7 @@ function Player:get_name() return self.name end
 return Player
 
 --[[
-Copyright (c) 2013, Jerry Hebert
+Copyright © 2013, Jerry Hebert
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/addons/scoreboard/scoreboard.lua
+++ b/addons/scoreboard/scoreboard.lua
@@ -2,7 +2,7 @@
 
 _addon.name = 'Scoreboard'
 _addon.author = 'Suji'
-_addon.version = '1.14'
+_addon.version = '1.15'
 _addon.commands = {'sb', 'scoreboard'}
 
 require('tables')
@@ -30,6 +30,9 @@ default_settings.visible = true
 default_settings.showfellow = true
 default_settings.UpdateFrequency = 0.5
 default_settings.combinepets = true
+default_settings.oneperline = false
+default_settings.compactsc = false
+default_settings.compactpets = false
 
 default_settings.display = {}
 default_settings.display.pos = {}
@@ -84,17 +87,17 @@ windower.register_event('addon command', function()
             sb_output('Scoreboard v' .. _addon.version .. '. Author: Suji')
             sb_output('sb help : Shows help message')
             sb_output('sb pos <x> <y> : Positions the scoreboard')
-            sb_output('sb reset : Reset damage')
+            sb_output('sb reset : Resets damage')
             sb_output('sb report [<target>] : Reports damage. Can take standard chatmode target options.')
             sb_output('sb reportstat <stat> [<player>] [<target>] : Reports the given stat. Can take standard chatmode target options. Ex: //sb rs acc p')
-            sb_output('Valid chatmode targets are: ' .. chatmodes:concat(', '))
-            sb_output('sb filter show  : Shows current filter settings')
-            sb_output('sb filter add <mob1> <mob2> ... : Add mob patterns to the filter (substrings ok)')
+            sb_output('  Valid chatmode targets are: ' .. chatmodes:concat(', '))
+            sb_output('sb filter show : Shows current filter settings')
+            sb_output('sb filter add <mob1> <mob2> ... : Adds mob patterns to the filter (substrings ok)')
             sb_output('sb filter clear : Clears mob filter')
             sb_output('sb visible : Toggles scoreboard visibility')
-            sb_output('sb stat <stat> [<player>]: Shows specific damage stats. Respects filters. If player isn\'t specified, ' ..
-                  'stats for everyone are displayed. Valid stats are:')
-            sb_output(dps_db.player_stat_fields:tostring():stripchars('{}"'))
+            sb_output('sb stat <stat> [<player>] : Shows specific damage stats. Respects filters. If player isn\'t specified, stats for everyone are displayed.')
+            sb_output('  Valid stats are: '..dps_db.player_stat_fields:tostring():stripchars('{}"'))
+            sb_output('sb set <flag> <value> : Sets configuration variables')
         elseif command == 'pos' then
             if params[2] then
                 local posx, posy = tonumber(params[1]), tonumber(params[2])
@@ -175,6 +178,39 @@ windower.register_event('addon command', function()
                 
                 settings:save()
                 sb_output("Setting 'showfellow' set to " .. tostring(settings.showfellow))
+            elseif setting == 'oneperline' then
+                if params[2] == 'true' then
+                    settings.oneperline = true
+                elseif params[2] == 'false' then
+                    settings.oneperline = false
+                else
+                    error("Invalid value for 'oneperline'. Must be true or false.")
+                    return
+                end
+                settings:save()
+                sb_output("Setting 'oneperline' set to " .. tostring(settings.oneperline))
+            elseif setting == 'compactsc' then
+                if params[2] == 'true' then
+                    settings.compactsc = true
+                elseif params[2] == 'false' then
+                    settings.compactsc = false
+                else
+                    error("Invalid value for 'compactsc'. Must be true or false.")
+                    return
+                end
+                settings:save()
+                sb_output("Setting 'compactsc' set to " .. tostring(settings.compactsc))
+            elseif setting == 'compactpets' then
+                if params[2] == 'true' then
+                    settings.compactpets = true
+                elseif params[2] == 'false' then
+                    settings.compactpets = false
+                else
+                    error("Invalid value for 'compactpets'. Must be true or false.")
+                    return
+                end
+                settings:save()
+                sb_output("Setting 'compactpets' set to " .. tostring(settings.compactpets))
             end
         elseif command == 'reset' then
             reset()
@@ -448,13 +484,23 @@ function action_handler(raw_actionpacket)
                 
                 if add and add.conclusion then
                     local actor_name = create_mob_name(actionpacket)
-                    if T{196,223,288,289,290,291,292,
-                        293,294,295,296,297,298,299,
-                        300,301,302,385,386,387,388,
-                        389,390,391,392,393,394,395,
-                        396,397,398,732,767,768,769,770}:contains(add.message_id) then
-                        actor_name = string.format("Skillchain(%s%s)", actor_name:sub(1, 3),
-                                                      actor_name:len() > 3 and '.' or '')
+                    if not settings.compactsc then
+                        if T{196,223,288,289,290,291,292,
+                            293,294,295,296,297,298,299,
+                            300,301,302,385,386,387,388,
+                            389,390,391,392,393,394,395,
+                            396,397,398,732,767,768,769,770}:contains(add.message_id) then
+                            actor_name = string.format("Skillchain(%s%s)", actor_name:sub(1, 3),
+                                                        actor_name:len() > 3 and '.' or '')
+                        end
+                    else
+                        if T{196,223,288,289,290,291,292,
+                            293,294,295,296,297,298,299,
+                            300,301,302,385,386,387,388,
+                            389,390,391,392,393,394,395,
+                            396,397,398,732,767,768,769,770}:contains(add.message_id) then
+                            actor_name = string.format("SC:%s", actor_name:sub(1, 13))
+                        end
                     end
                     if add.conclusion.subject == 'target' and T(add.conclusion.objects):contains('HP') and add.param ~= 0 then
                         dps_db:add_damage(target:get_name(), actor_name, (add.conclusion.verb == 'gains' and -1 or 1)*add.param)
@@ -496,13 +542,19 @@ ActionPacket.open_listener(action_handler)
         return name, pet.name
     end
 
-    function create_mob_name(actionpacket)
-        local actor = actionpacket:get_actor_name()
-        local result = ''
-        local owner, pet = find_pet_owner_name(actionpacket)
-        if owner ~= nil then
-            if string.len(actor) > 8 then
-                result = string.sub(actor, 1, 7)..'.'
+function create_mob_name(actionpacket)
+    local actor = actionpacket:get_actor_name()
+    local result = ''
+    local owner = find_pet_owner_name(actionpacket)
+    if owner ~= nil then
+        if string.len(actor) > 8 then
+            result = string.sub(actor, 1, 7)..'.'
+        else
+            result = actor
+        end
+        if settings.combinepets then
+            if settings.compactpets then
+                result = 'Pets:'
             else
                 result = actor
             end
@@ -517,7 +569,13 @@ ActionPacket.open_listener(action_handler)
         else
             return actor
         end
-        return result
+        if settings.compactpets then
+            result = result..string.sub(owner, 1, 11)
+        else
+            result = result..' ('..string.sub(owner, 1, 3)..'.)'
+        end
+    else
+        return actor
     end
 
 config.register(settings, function(settings)
@@ -527,7 +585,7 @@ end)
 
 
 --[[
-Copyright � 2013-2014, Jerry Hebert
+Copyright (c) 2013-2014, Jerry Hebert
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without


### PR DESCRIPTION
Added a mode to scoreboard (disabled by default; enabled with `//sb set alternateoutput true`) which minimizes skillchain/pet headers and maximizes player names, as well as reporting one entity per line for better legibility.

![image](https://user-images.githubusercontent.com/1747598/97797378-cd3b4980-1bd9-11eb-8b66-52baa3c8df11.png)

![image](https://user-images.githubusercontent.com/1747598/97797385-d7f5de80-1bd9-11eb-9cb0-1580f58c2f07.png)
