### PR TITLE
Fix player pet check

### DIFF
--- a/addons/autocontrol/autocontrol.lua
+++ b/addons/autocontrol/autocontrol.lua
@@ -80,14 +80,14 @@ function initialize()
         windower.send_command('@wait 5;lua i autocontrol initialize')
         return
     end
-    local playermob = windower.ffxi.get_mob_by_id(player.id)
+    local playermob = windower.ffxi.get_mob_by_index(player.index)
     mjob_id = player.main_job_id
     atts = res.items:category('Automaton')
     decay = 1
     for key,_ in pairs(heat) do
         heat[key] = 0
         Burden_tb[key] = 0
-        Burden_tb['time' .. key] = 0 
+        Burden_tb['time' .. key] = 0
     end
     if mjob_id == 18 then
         if playermob.pet_index and playermob.pet_index ~= 0 then
@@ -113,8 +113,8 @@ function attach_set(autoset)
         return
     end
 
-    local playermob = windower.ffxi.get_mob_by_id(windower.ffxi.get_player().id)
     if playermob.pet_index and playermob.pet_index ~= 0 then 
+    local playermob = windower.ffxi.get_mob_by_index(windower.ffxi.get_player().index)
         local recast = windower.ffxi.get_ability_recasts()[recast_ids.deactivate]
         if recast == 0 then
             windower.send_command('input /pet "Deactivate" <me>')

--- a/addons/autocontrol/autocontrol.lua
+++ b/addons/autocontrol/autocontrol.lua
@@ -80,7 +80,7 @@ function initialize()
         windower.send_command('@wait 5;lua i autocontrol initialize')
         return
     end
-
+    local playermob = windower.ffxi.get_mob_by_id(player.id)
     mjob_id = player.main_job_id
     atts = res.items:category('Automaton')
     decay = 1
@@ -90,7 +90,7 @@ function initialize()
         Burden_tb['time' .. key] = 0 
     end
     if mjob_id == 18 then
-        if player.pet_index then 
+        if playermob.pet_index and playermob.pet_index ~= 0 then
             running = 1
             text_update_loop('start')
             if settings.burdentracker then

--- a/addons/autocontrol/maneuver.lua
+++ b/addons/autocontrol/maneuver.lua
@@ -91,7 +91,7 @@ Burden_tb = texts.new(str, settings)
 windower.register_event("action", function(act)
     if mjob_id == 18 then
         local abil_ID = act['param']
-        local actor_index = act['actor_index']
+        local actor_id = act['actor_id']
         local player = T(windower.ffxi.get_player())
         
         local pet_index = windower.ffxi.get_mob_by_index(windower.ffxi.get_player()['index'])['pet_index']
@@ -144,7 +144,7 @@ windower.register_event("action", function(act)
                 Burden_tb:hide()
             end
         elseif S{1688,1689,1690,1691,1692,1755,1765,1812,1876,2489,2490,2491}:contains(abil_ID-256)
-               and windower.ffxi.get_mob_by_index(actor_index)['index'] == pet_index
+               and windower.ffxi.get_mob_by_id(actor_id)['index'] == pet_index
                and pet_index ~= nil then
                 local abil = abil_ID - 256
                 windower.send_command('@timers c "'..autoabils[abil].name..'" '..autoabils[abil].recast..' up')

--- a/addons/autocontrol/maneuver.lua
+++ b/addons/autocontrol/maneuver.lua
@@ -91,10 +91,10 @@ Burden_tb = texts.new(str, settings)
 windower.register_event("action", function(act)
     if mjob_id == 18 then
         local abil_ID = act['param']
-        local actor_id = act['actor_id']
+        local actor_index = act['actor_index']
         local player = T(windower.ffxi.get_player())
-        local pet_index = windower.ffxi.get_mob_by_id(windower.ffxi.get_player()['id'])['pet_index']
         
+        local pet_index = windower.ffxi.get_mob_by_index(windower.ffxi.get_player()['index'])['pet_index']
         if act['category'] == 6 and actor_id == player.id and S{136,139,141,142,143,144,145,146,147,148,309,310}:contains(abil_ID) then
             if S{141, 142, 143, 144, 145, 146, 147, 148}:contains(abil_ID) and maneuvertimers then
                 windower.send_command('timers c "Maneuver: '..maneuver..'" 60 down')
@@ -143,8 +143,8 @@ windower.register_event("action", function(act)
                 text_update_loop('stop')
                 Burden_tb:hide()
             end
-        elseif S{1688,1689,1690,1691,1692,1755,1765,1812,1876,2489,2490,2491}:contains(abil_ID-256) 
-               and windower.ffxi.get_mob_by_id(actor_id)['index'] == pet_index 
+        elseif S{1688,1689,1690,1691,1692,1755,1765,1812,1876,2489,2490,2491}:contains(abil_ID-256)
+               and windower.ffxi.get_mob_by_index(actor_index)['index'] == pet_index
                and pet_index ~= nil then
                 local abil = abil_ID - 256
                 windower.send_command('@timers c "'..autoabils[abil].name..'" '..autoabils[abil].recast..' up')
@@ -328,7 +328,7 @@ function text_update_loop(str)
             end
             Burden_tb:update()
             
-            local player_mob = windower.ffxi.get_mob_by_id(windower.ffxi.get_player()['id'])
+            local player_mob = windower.ffxi.get_mob_by_index(windower.ffxi.get_player()['index'])
             if player_mob then
                 if player_mob['pet_index']
                    and player_mob['pet_index'] ~= 0 then 


### PR DESCRIPTION
Pretty sure that player.pet_index doesn't exist/always returns `nil`? Tested by adding debugs and loading autocontrol with pet already active.

The validation on line 93 is the same as used later.