### PR TITLE
burden.lua fix typo

### DIFF
--- a/addons/autocontrol/autocontrol.lua
+++ b/addons/autocontrol/autocontrol.lua
@@ -27,7 +27,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ]]
 
 _addon.name = 'autocontrol'
-_addon.version = '2.0.1'
+_addon.version = '2.0.2'
 _addon.author = 'Nitrous (Shiva)'
 _addon.commands = {'autocontrol','acon'}
 

--- a/addons/autocontrol/burden.lua
+++ b/addons/autocontrol/burden.lua
@@ -21,9 +21,9 @@ local heatsink
 
 windower.register_event('incoming chunk',function(id,org,modi,is_injected,is_blocked)
     if id == 0x044 then
-        attachments = windower.ffxi.get_mjob_data().attachments
-        if attachements then
-            for _, id in pairs(attachements) do
+        local attachments = windower.ffxi.get_mjob_data().attachments
+        if attachments then
+            for _, id in pairs(attachments) do
                 heatsink = (id == 8610)
                 if heatsink then
                     break

--- a/addons/autocontrol/readme.md
+++ b/addons/autocontrol/readme.md
@@ -1,5 +1,5 @@
 **Author:** Ricky Gall  
-**Version:** 0.21  
+**Version:** 2.0.2
 **Description:**  
 Addon to make setting automaton attachments easier. Currently only works as pup main. Includes burden tracker.  
 


### PR DESCRIPTION
 * correct `attachements` to `attachments`
 * add `local` to `attachments` definition