### PR TITLE
Autocontrol: Add load event to autoabils.lua

### DIFF
--- a/addons/autocontrol/autoabils.lua
+++ b/addons/autocontrol/autoabils.lua
@@ -39,6 +39,11 @@ windower.register_event("login", function()
     player_id = windower.ffxi.get_player().id
 end)
 
+windower.register_event("load", function()
+    local player = windower.ffxi.get_player()
+    player_id = player and player.id
+end)
+
 windower.register_event("action", function(act)
     local abil_ID = act['param']
     local actor_id = act['actor_id']

--- a/addons/autocontrol/autocontrol.lua
+++ b/addons/autocontrol/autocontrol.lua
@@ -27,7 +27,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ]]
 
 _addon.name = 'autocontrol'
-_addon.version = '2.0.2'
+_addon.version = '2.0.3'
 _addon.author = 'Nitrous (Shiva)'
 _addon.commands = {'autocontrol','acon'}
 

--- a/addons/autocontrol/readme.md
+++ b/addons/autocontrol/readme.md
@@ -1,5 +1,5 @@
 **Author:** Ricky Gall  
-**Version:** 2.0.2
+**Version:** 2.0.3
 **Description:**  
 Addon to make setting automaton attachments easier. Currently only works as pup main. Includes burden tracker.  
 


### PR DESCRIPTION
`player_id` was nil if addon was loaded after login event.