### PR TITLE
AutoControl 2.0.5: Bug Fix in burden.lua

### DIFF
--- a/addons/autocontrol/autocontrol.lua
+++ b/addons/autocontrol/autocontrol.lua
@@ -27,7 +27,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ]]
 
 _addon.name = 'autocontrol'
-_addon.version = '2.0.4'
+_addon.version = '2.0.5'
 _addon.author = 'Nitrous (Shiva)'
 _addon.commands = {'autocontrol','acon'}
 

--- a/addons/autocontrol/burden.lua
+++ b/addons/autocontrol/burden.lua
@@ -177,7 +177,7 @@ function burden.update_decay_rate()
                 count = count + 1
             end
         end
-        burden.decay_rate = count_to_rate[count];
+        burden.decay_rate = count_to_decay_rate[count];
     else
         burden.decay_rate = 1
     end


### PR DESCRIPTION
Bug Fix: `autocontrol/burden.lua:180: attempt to index global 'count_to_rate' (a nil value)`'
   * change `count_to_rate` to `count_to_decay_rate`
