### PR TITLE
Update FastCS.lua

### DIFF
--- a/addons/FastCS/FastCS.lua
+++ b/addons/FastCS/FastCS.lua
@@ -1,6 +1,6 @@
 _addon.name = "FastCS"
 _addon.author = "Cairthenn"
-_addon.version = "1.2"
+_addon.version = "1.3"
 _addon.commands = {"FastCS","FCS"}
 
 --Requires:
@@ -11,7 +11,7 @@ require("luau")
 
 defaults = {}
 defaults.frame_rate_divisor = 2
-defaults.exclusions = S{"home point #1", "home point #2", "home point #3", "home point #4", "home point #5", "survival guide", "waypoint"}
+defaults.exclusions = S{"home point #1", "home point #2", "home point #3", "home point #4", "home point #5", "igsli", "urbiolaine", "teldro-kesdrodo", "nunaarl bthtrogg", "survival guide", "waypoint"}
 settings = config.load(defaults)
 
 -- Globals:


### PR DESCRIPTION
Add the unity warp NPCs to the exclusion list(currently, only home points books and waypoints are excluded)