### PR TITLE
Added automatic creation of default.lua user profile

### DIFF
--- a/addons/GearSwap/gearswap.lua
+++ b/addons/GearSwap/gearswap.lua
@@ -136,6 +136,11 @@ windower.register_event('load',function()
     windower.debug('load')
     refresh_globals()
     
+    if not file.exists('data\\default.lua') then
+        file.new('data\\default.lua',true):write('-- this file was generated automatically and can be safely overwritten.')
+        print('GearSwap: A default user profile (default.lua) has been created.')
+    end
+
     if world.logged_in then
         refresh_user_env()
         if debugging.general then windower.send_command('@unload spellcast;') end


### PR DESCRIPTION
The functionality to resolve target IDs passed to commands in the chatlog, upon which the send command relies for the <tid> parameters to work, only works when gearswap has an user profile loaded and active. This leads to many complaints that the functionality is not working, simply because it's being used on a character without gearswap, or without a profile loaded.

This change will make gearswap create an empty default.lua on load, which is sufficient for it to become active and start resolving target IDs.

(I am not sure about the wording of the notice, and of the contents of the empty file. I am also not sure about the place - doing it on load feels the most appropriate. I'm open to suggestions on all of these.)