### PR TITLE
Fixes player.mp error on load

### DIFF
--- a/addons/GearSwap/packet_parsing.lua
+++ b/addons/GearSwap/packet_parsing.lua
@@ -702,13 +702,15 @@ end
 
 function initialize_packet_parsing()
     for i,v in pairs(parse.i) do
-        local lastpacket = windower.packets.last_incoming(i)
-        if lastpacket then
-            v(lastpacket)
-        end
-        if i == 0x63 and lastpacket and lastpacket:byte(5) ~= 9 then
-            -- Not receiving an accurate buff line on load because the wrong 0x063 packet was sent last
+        if i ~= 0x028 then
+            local lastpacket = windower.packets.last_incoming(i)
+            if lastpacket then
+                v(lastpacket)
+            end
+            if i == 0x63 and lastpacket and lastpacket:byte(5) ~= 9 then
+                -- Not receiving an accurate buff line on load because the wrong 0x063 packet was sent last
             
+            end
         end
     end
 end


### PR DESCRIPTION
When gearswap is loaded, it is initializing stuff basically by re-parsing stuff from windower.packets.last_incoming() by looping over its handlers for various packets.
This includes the last 0x028 which relies on knowing the players MP (for checking if you have enough mp to cast the spell). So if it parses the last 0x028 before it parses 0x0DF or 0x0E2 then an error occurs. So this solution just ignores the last 0x028.