### PR TITLE
Equipviewer -- Private Server Ammo disappear bandaid

### DIFF
--- a/addons/equipviewer/equipviewer.lua
+++ b/addons/equipviewer/equipviewer.lua
@@ -256,7 +256,7 @@ windower.register_event('incoming chunk', function(id, original, modified, injec
         end
         
         if slot then
-            if packet['Status'] ~= 5 then --item not equipped
+            if packet['Status'] ~= 5 and packet['Count'] == 0 then --item not equipped
                 update_equipment_slot:schedule(0, '0x%x':format(id), slot, 0, 0, 0)
                 return
             end


### PR DESCRIPTION
For our overlords the private servers.
(Private servers are (improperly) using 0x01E to report ammo changes to client in a way retail never does -- checking if the count field from the packet is 0 will better validate if I should remove the item from display)