### PR TITLE
Fix JobChange to work properly in Odyssey

### DIFF
--- a/addons/JobChange/jobchange.lua
+++ b/addons/JobChange/jobchange.lua
@@ -64,14 +64,23 @@ local find_conflict = function(job_name, p)
     end
 end
 
+injected_poke = false
 local poke = function(npc)
    local p = packets.new('outgoing', 0x1a, {
       ["Target"] = npc.id,
       ["Target Index"] = npc.index,
       })
+      injected_poke = true
       packets.inject(p) 
 end
-
+windower.register_event('incoming chunk',function(id,data,modified,injected,blocked)
+   local p = packets.parse('incoming',data)
+	if id == 0x02E and injected_poke then
+	   injected_poke = false
+      return true
+   end
+end)
+   
 local find_temp_job = function(p)
     for _, job_name in ipairs(temp_jobs) do
         if not find_conflict(job_name, p) and p.jobs[job_name:upper()] > 0 then 

--- a/addons/JobChange/jobchange.lua
+++ b/addons/JobChange/jobchange.lua
@@ -64,6 +64,14 @@ local find_conflict = function(job_name, p)
     end
 end
 
+local poke = function(npc)
+   local p = packets.new('outgoing', 0x1a, {
+      ["Target"] = npc.id,
+      ["Target Index"] = npc.index,
+      })
+      packets.inject(p) 
+end
+
 local find_temp_job = function(p)
     for _, job_name in ipairs(temp_jobs) do
         if not find_conflict(job_name, p) and p.jobs[job_name:upper()] > 0 then 
@@ -191,6 +199,10 @@ windower.register_event('addon command', function(command, ...)
 
     local npc = find_job_change_npc()
     if npc then
+        if npc.name == 'Nomad Moogle' or npc.name == 'Pilgrim Moogle'then
+            poke(npc)
+            coroutine.sleep(1) -- the moogles don't return an 0x032~0x034 so can't job change in response to an incoming menu packet.
+        end
         for _, change in ipairs(changes) do
             if change.is_conflict then
                 log('Conflict with '..(change.is_main and 'main' or 'sub')..' job. Changing to: '..res.jobs[change.job_id].ens)
@@ -198,7 +210,6 @@ windower.register_event('addon command', function(command, ...)
                 log('Changing '..(change.is_main and 'main' or 'sub')..' job to: '..res.jobs[change.job_id].ens)
             end
             jobchange(change.job_id, change.is_main)
-
             coroutine.sleep(0.5)
         end
     else


### PR DESCRIPTION
This is a change to job change to allow it to work consistently in Odyssey. 

The first time you enter Idyssey the server will accept an `0x100`, but once you initiate an NM fight the sever will no longer accept an `0x100` until you poke the Moogle again without the BCNM flag. I added a poke for Nomad Moogles as well since technically there is no manual way to change jobs without poking a Nomad Moogle, and if SE wanted to get banhappy it's something they could easily look for.

Note -- changing jobs manually the first time you enter the BC, the last two bytes(unknown 1 & 2) are empty, but once you've killed an NM -- they do contain *some* values, but they don't seem to be related to anything related to the event. The server still accepts a traditional `0x100`.