### PR TITLE
Further improved Nomad/Pilgrim Moogle check

### DIFF
--- a/addons/organizer/items.lua
+++ b/addons/organizer/items.lua
@@ -76,7 +76,7 @@ do
         return false
     end
     
-    windower.register_event('incoming chunk',function(id,data,modified,injected,blocked)
+    windower.register_event('incoming chunk',function(id)
         if id == 0x02E and block_menu then
             block_menu = false
             return true

--- a/addons/organizer/items.lua
+++ b/addons/organizer/items.lua
@@ -41,7 +41,6 @@ do
     end
     
     local poke_moogle = function(npc)
-        print('poking', npc.name)
         local p = packets.new('outgoing', 0x1a, {
             ["Target"] = npc.id,
             ["Target Index"] = npc.index,
@@ -51,7 +50,6 @@ do
         packets.inject(p)
         repeat 
             coroutine.sleep(0.4)
-            print('waitan')
         until not block_menu
     end
     
@@ -61,7 +59,6 @@ do
                 local npcs = windower.ffxi.get_mob_list(name)
                 for index in pairs(npcs) do
                     table.insert(moogles,index)
-                    print(name,index)
                 end
             end
         end
@@ -81,7 +78,6 @@ do
     
     windower.register_event('incoming chunk',function(id,data,modified,injected,blocked)
         if id == 0x02E and block_menu then
-            print('moogle poked, menu blocked')        
             block_menu = false
             return true
         end

--- a/addons/organizer/organizer.lua
+++ b/addons/organizer/organizer.lua
@@ -246,7 +246,7 @@ windower.register_event('addon command',function(...)
 
     local moogle = nomad_moogle()
     if moogle then
-        org_debug("command","Using '" .. mog .. "' for Mog House interaction")
+        org_debug("command","Using '" .. moogle .. "' for Mog House interaction")
     end
     
     local bag = 'all'

--- a/addons/organizer/organizer.lua
+++ b/addons/organizer/organizer.lua
@@ -24,18 +24,18 @@
 --(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 --SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-res = require 'resources'
-files = require 'files'
-require 'pack'
-Items = require 'items'
-extdata = require 'extdata'
-logger = require 'logger'
-require 'tables'
-require 'lists'
-require 'functions'
-config = require 'config'
-slips = require 'slips'
-packets = require 'packets'
+res = require('resources')
+files = require('files')
+require('pack')
+Items = require('items')
+extdata = require('extdata')
+logger = require('logger')
+require('tables')
+require('lists')
+require('functions')
+config = require('config')
+slips = require('slips')
+packets = require('packets')
 
 _addon.name = 'Organizer'
 _addon.author = 'Byrth, maintainer: Rooks'
@@ -246,7 +246,7 @@ windower.register_event('addon command',function(...)
 
     local moogle = nomad_moogle()
     if moogle then
-        org_debug("command","Using '" .. moogle .. "' for Mog House interaction")
+        org_debug("command", "Using '" .. moogle .. "' for Mog House interaction")
     end
     
     local bag = 'all'
@@ -307,7 +307,7 @@ windower.register_event('addon command',function(...)
 
     if moogle then
         clear_moogle()
-        org_debug("command","Clearing '" .. moogle .. "' status")
+        org_debug("command", "Clearing '" .. moogle .. "' status")
     end
     
     org_debug("command", "Organizer complete")

--- a/addons/organizer/organizer.lua
+++ b/addons/organizer/organizer.lua
@@ -35,6 +35,7 @@ require 'lists'
 require 'functions'
 config = require 'config'
 slips = require 'slips'
+packets = require 'packets'
 
 _addon.name = 'Organizer'
 _addon.author = 'Byrth, maintainer: Rooks'
@@ -243,6 +244,11 @@ windower.register_event('addon command',function(...)
         return
     end
 
+    local moogle = nomad_moogle()
+    if moogle then
+        org_debug("command","Using '" .. mog .. "' for Mog House interaction")
+    end
+    
     local bag = 'all'
     if inp[1] and (_static.bag_ids[inp[1]:lower()] or inp[1]:lower() == 'all') then
         bag = table.remove(inp,1):lower()
@@ -299,6 +305,11 @@ windower.register_event('addon command',function(...)
         windower.send_command('input /heal')
     end
 
+    if moogle then
+        clear_moogle()
+        org_debug("command","Clearing '" .. moogle .. "' status")
+    end
+    
     org_debug("command", "Organizer complete")
 
 end)


### PR DESCRIPTION
Check for Nomad/Pilgrim Moogles at the start of the command.
Added appropriate debug notices.
Initiate menu interaction with the appropriate Moogle before pulling items from Mog House bags.