### PR TITLE
Version bump and Pilgrim Moogle removal.

### DIFF
--- a/addons/organizer/items.lua
+++ b/addons/organizer/items.lua
@@ -30,7 +30,7 @@ local bags = {}
 local item_tab = {}
 
 do
-    local names = {'Nomad Moogle', 'Pilgrim Moogle'}
+    local names = {'Nomad Moogle'} -- don't add Pilgrim Moogle to this list, organizer currently does not work in Odyssey.
     local moogles = {}
     local poked = false
     local block_menu = false

--- a/addons/organizer/organizer.lua
+++ b/addons/organizer/organizer.lua
@@ -39,7 +39,7 @@ packets = require('packets')
 
 _addon.name = 'Organizer'
 _addon.author = 'Byrth, maintainer: Rooks'
-_addon.version = 0.20210610
+_addon.version = 0.20210721
 _addon.commands = {'organizer','org'}
 
 _static = {


### PR DESCRIPTION
Until we understand why organizer is choking in Odyssey, I disabled the Pilgrim Moogle from that area so organizer stays functional, albeit partially (it won't pull from Mog House bags, but will be able to pull from world-available bags instead of just erroring out)