### PR TITLE
Update to properly handle more valid commands

### DIFF
--- a/addons/GearSwap/triggers.lua
+++ b/addons/GearSwap/triggers.lua
@@ -44,8 +44,8 @@ windower.register_event('outgoing text',function(original,modified,blocked,ffxi,
     windower.debug('outgoing text')
     if gearswap_disabled then return modified end
     
-    local splitline = windower.from_shift_jis(windower.convert_auto_trans(modified)):gsub(' <wait %d+>',''):gsub('"(.-)"',function(str)
-            return str:gsub(' ',string.char(7))
+    local splitline = windower.from_shift_jis(windower.convert_auto_trans(modified)):gsub('<wait[%s%d%.]*>',''):gsub('"(.-)"',function(str)
+            return ' '..str:gsub(' ',string.char(7))..' '
         end):split(' '):filter(-'')
     
     if splitline.n == 0 then return end


### PR DESCRIPTION
Now will properly swap for valid commands such as
`/ma "Garuda"<me>` and `/ma "Elemental Siphon"<me>`
Also will now properly handle (ignore) more valid forms of waits such as
`<wait>` and `<wait 1.2>`
and waits that are not preceded by a space
`/ma garuda <me><wait 2.2>`

See discord #development discussion for additional context: https://discord.com/channels/338590234235371531/501099842097905675/880870405966024784