### PR TITLE
pointwatch does not get Capacity/Job Points in Japanese environment.

### DIFF
--- a/addons/pointwatch/pointwatch.lua
+++ b/addons/pointwatch/pointwatch.lua
@@ -125,9 +125,12 @@ packet_handlers = {
             lp.number_of_merits = p['Merit Points']
             lp.maximum_merits = p['Max Merit Points']
         elseif p['Order'] == 5 then
-            local job = windower.ffxi.get_player().main_job_full
-            cp.current = p[job..' Capacity Points']
-            cp.number_of_job_points = p[job..' Job Points']
+            local player = windower.ffxi.get_player()
+            if player then 
+                local job = res.jobs[player.main_job_id].name
+                cp.current = p[job..' Capacity Points']
+                cp.number_of_job_points = p[job..' Job Points']
+            end
         end
     end,
     [0x110] = function(org)


### PR DESCRIPTION
When packets.parse (incoming packet 0x63 Order=5) in Japanese environment, job name is Japanese name in the parsed data.
For example, Warrior Capacity Point is p['戦士 Capacity Points']. Job Point is the same too.
windower.ffxi.get_player().main_job_full returns English name.
Fixed to get the job name that suits your language environment by using res.jobs[job_id].name.

 I would like you to merge, if there is no problem in English environment.