### PR TITLE
pointwatch: Scrape two high bits off the message ID so that it matches the dialog file ID

### DIFF
--- a/addons/pointwatch/pointwatch.lua
+++ b/addons/pointwatch/pointwatch.lua
@@ -65,11 +65,11 @@ packet_handlers = {
         local p = packets.parse('incoming',org)
         local zone = 'z'..windower.ffxi.get_info().zone
         if settings.options.message_printing then
-            print('Message ID: '..p['Message ID'])
+            print('Message ID: '..bit.band(p['Message ID'], 16383))
         end
         
         if messages[zone] then
-            local msg = p['Message ID']
+            local msg = bit.band(p['Message ID'], 16383)
             for i,v in pairs(messages[zone]) do
                 if tonumber(v) and v + messages[zone].offset == msg then
                     -- print(p['Param 1'],p['Param 2'],p['Param 3'],p['Param 4']) -- DEBUGGING STATEMENT -------------------------


### PR DESCRIPTION
Pointwatch used to scrape off the two highest bits. Why two? Not sure.
There's a comment in fields.lua that the high bit is sometimes set for unknown reasons, which accounts for the highest bit.
As for the next highest bit... There are a few zones which have more than 2^14-1 ids, but none are Abyssean zones. It might have been a mistake, but it shouldn't matter for pointwatch's purposes.