### PR TITLE
GearSwap Motes Command-- set mode with spaces

### DIFF
--- a/addons/GearSwap/libs/Mote-SelfCommands.lua
+++ b/addons/GearSwap/libs/Mote-SelfCommands.lua
@@ -53,7 +53,7 @@ function handle_set(cmdParams)
     
     if state_var then
         local oldVal = state_var.value
-        state_var:set(cmdParams[2])
+        state_var:set(T{cmdParams:select(2)}:concat(' '))
         local newVal = state_var.value
         
         local descrip = state_var.description or cmdParams[1]

--- a/addons/GearSwap/libs/Mote-SelfCommands.lua
+++ b/addons/GearSwap/libs/Mote-SelfCommands.lua
@@ -53,7 +53,7 @@ function handle_set(cmdParams)
     
     if state_var then
         local oldVal = state_var.value
-        state_var:set(T{cmdParams:select(2)}:concat(' '))
+        state_var:set(cmdParams:slice(2):concat(' '))
         local newVal = state_var.value
         
         local descrip = state_var.description or cmdParams[1]


### PR DESCRIPTION
Allow to set a specific mode name with a space in it via `gs c set` (previously would ignore anything after a space, even if contained in quotes)