### PR TITLE
eager-load resources for actions.lua

### DIFF
--- a/addons/GearSwap/gearswap.lua
+++ b/addons/GearSwap/gearswap.lua
@@ -113,7 +113,7 @@ require 'actions'
 packets = require 'packets'
 
 -- Resources Checks
-if res.items and res.bags and res.slots and res.statuses and res.jobs and res.elements and res.skills and res.buffs and res.spells and res.job_abilities and res.weapon_skills and res.monster_skills and res.action_messages and res.skills and res.monstrosity and res.weather and res.moon_phases and res.races then
+if res.items and res.bags and res.slots and res.statuses and res.jobs and res.elements and res.skills and res.buffs and res.spells and res.job_abilities and res.weapon_skills and res.monster_skills and res.action_messages and res.skills and res.monstrosity and res.weather and res.moon_phases and res.races and res.monster_abilities then
 else
     error('Missing resources!')
 end

--- a/addons/libs/actions.lua
+++ b/addons/libs/actions.lua
@@ -356,6 +356,14 @@ local cat_to_res_map = {['weaponskill_finish']='weapon_skills', ['spell_finish']
     ['casting_begin']='spells', ['item_begin']='items', ['mob_tp_finish']='monster_abilities',
     ['avatar_tp_finish']='job_abilities', ['job_ability_unblinkable']='job_abilities',
     ['job_ability_run']='job_abilities'}
+-- This library uses rawget() to index the resources for performance reasons.
+-- However, the resources library lazy-loads resources using its metatable.
+-- Thus we need to index each of the required resources once to force an eager-load.
+for _,resource_name in pairs(cat_to_res_map) do
+    if not res[resource_name] then
+        print(resource_name.." not detected.")
+    end
+end
 local begin_categories = {['weaponskill_begin']=true, ['casting_begin']=true, ['item_begin']=true, ['ranged_begin']=true}
 local finish_categories = {['melee']=true,['ranged_finish']=true,['weaponskill_finish']=true, ['spell_finish']=true, ['item_finish']=true,
     ['job_ability']=true, ['mob_tp_finish']=true, ['avatar_tp_finish']=true, ['job_ability_unblinkable']=true,


### PR DESCRIPTION
The `resources` lib lazy-loads resources using a metatable to avoid extra RAM overhead where it loads resources it doesn't need.
The `actions` lib bypasses its metatables (line 203 with the rawgets) to avoid the performance hit they cause.

While both design decisions make sense in isolation, unfortunately this means you must index the resources you're going to parse actions out of once or it'll throw obscure rawget errors.

I fixed this in both gearswap and libs/actions.lua