### PR TITLE
Switch indinope to use the modified packet

### DIFF
--- a/addons/indinope/indinope.lua
+++ b/addons/indinope/indinope.lua
@@ -38,11 +38,11 @@ windower.register_event('incoming chunk', function(id, original, modified, injec
     if injected or blocked or not offsets[id] then return end
 
     offset = offsets[id]
-    flags = original:byte(offsets[id])
+    flags = modified:byte(offsets[id])
 
     -- if any of the bits 0 through 7 are set, a bubble is shown and we want to block it.
     if bit.band(flags, 0x7F) ~= 0 then
-        packet = original:sub(1, offset - 1) .. string.char(bit.band(flags, 0x80)) .. original:sub(offset + 1) -- preserve bit 8 (Job Master stars)
+        packet = modified:sub(1, offset - 1) .. string.char(bit.band(flags, 0x80)) .. modified:sub(offset + 1) -- preserve bit 8 (Job Master stars)
         return packet
     end
 end)


### PR DESCRIPTION
Indinope modifies incoming player information packets, but currently it also effectively resets all of their other bits by returning a chunk assembled from the `original` packet instead of `modified`. This adjusts it so it will no longer interfere with other addons that might be modifying those packets.