### PR TITLE
Update checkparam.lua

### DIFF
--- a/addons/checkparam/checkparam.lua
+++ b/addons/checkparam/checkparam.lua
@@ -224,6 +224,7 @@ integrate = {
     ['indicolure spell duration'] = 'indicolure effect duration',
     ['indi eff dur'] = 'indicolure effect duration',
     ['mag eva'] = 'magic evasion',
+    ['magic eva'] = 'magic evasion',
     ['magic atk bonus'] = 'magic attack bonus',
     ['magatkbns'] = 'magic attack bonus',
     ['mag atk bonus'] = 'magic attack bonus',


### PR DESCRIPTION
Add in "magic eva" to cover items like Nyame Sollerets which wasn't capturing magic evasion