### PR TITLE
Support bug fix

### DIFF
--- a/addons/craft/craft.lua
+++ b/addons/craft/craft.lua
@@ -532,6 +532,7 @@ local function check_queue()
             end
             if support then
                 poke_npc()
+                coroutine.sleep(2)
             end
             if food then
                 consume_food()


### PR DESCRIPTION
Occasionally addon will try to resume crafting too quickly after interacting with support npc causing entire queue to be dumped with "you cannot craft at this time" errors.  Added a short delay in the check_queue function after poke_npc() call.