### PR TITLE
[gametime] fix //gt route

### DIFF
--- a/addons/gametime/gametime.lua
+++ b/addons/gametime/gametime.lua
@@ -1,4 +1,4 @@
--- Copyright © 2013-2016, Omnys of Valefor
+-- Copyright © 2013-2016, 2022, Omnys of Valefor
 -- All rights reserved.
 
 -- Redistribution and use in source and binary forms, with or without
@@ -26,7 +26,7 @@
 
 _addon.name = 'gametime'
 _addon.author = 'Omnys'
-_addon.version = '0.6'
+_addon.version = '0.7'
 _addon.commands = {'gametime','gt'}
 
 require('chat')

--- a/addons/gametime/gametime.lua
+++ b/addons/gametime/gametime.lua
@@ -287,6 +287,7 @@ end
 windower.register_event('time change', function(new, old)
     gt.hours = (new / 60):floor()
     gt.minutes = new % 60
+    gt.dectime = timeconvert(gt.hours..':'..gt.minutes)
     gt.gtt:update(gt)
 end)
 


### PR DESCRIPTION
`gt.dectime` was mistakenly removed in [this commit](https://github.com/Windower/Lua/commit/fc8990e871288da0480b1dda8443d91514a76204#diff-cd460b4859ff0c7879a36e5f5f705124f2a12cda0e84819a9b0bac753d77d159L308).

I checked in Selbina and the arrival times are correct.

![Selbina NPC's time + addon output](https://cdn.discordapp.com/attachments/484050756169760788/978709336333361222/unknown.png)