### PR TITLE
[Gearswap] Add aftercast equip trigger to fallback if the action isn't in the command registry

### DIFF
--- a/addons/GearSwap/triggers.lua
+++ b/addons/GearSwap/triggers.lua
@@ -256,6 +256,7 @@ parse.i[0x028] = function (data)
             equip_sets(prefix..'aftercast',ts,spell)
         elseif debugging.command_registry then
             msg.debugging('Hitting Aftercast without detecting an entry in command_registry')
+			equip_sets(prefix..'aftercast',nil,spell)
         end
     elseif (readies[act.category] and act.param == 28787) then -- and not (act.category == 9 or (act.category == 7 and prefix == 'pet_'))) then
         spell.action_type = 'Interruption'
@@ -268,6 +269,7 @@ parse.i[0x028] = function (data)
             equip_sets(prefix..'aftercast',ts,spell)
         elseif debugging.command_registry then
             msg.debugging('Hitting Aftercast without detecting an entry in command_registry')
+			equip_sets(prefix..'aftercast',nil,spell)
         end
     elseif readies[act.category] and prefix == 'pet_' and act.targets[1].actions[1].message ~= 0 then
         -- Entry for pet midcast. Excludes the second packet of "Out of range" BPs.


### PR DESCRIPTION
This fixes not swapping back to aftercast when an addon edits the outgoing packet 0x01A because gearswap isn't aware the incoming aftercast packet has a different param than it has registered in the command list.

[This ](https://github.com/Roland-J/Windower-Addons/tree/main/NukeDemoter) addon in particular is the addon in question that modifies 0x01A's param.
