### PR TITLE
[GearSwap] Item Aftercast triggered from Menu initiation

### DIFF
--- a/addons/GearSwap/helper_functions.lua
+++ b/addons/GearSwap/helper_functions.lua
@@ -602,9 +602,14 @@ end
 ---- bag_id - The item's bag ID (if it exists)
 -----------------------------------------------------------------------------------
 function find_usable_item(item_id)
+    --table.vprint(usable_item_bags)
     for _,bag in ipairs(usable_item_bags) do
+        --table.vprint(usable_item_bags)
+        --print(to_windower_bag_api(bag.en), items[to_windower_bag_api(bag.en)])
         for i,v in pairs(items[to_windower_bag_api(bag.en)]) do
+            
             if type(v) == 'table' and v.id == item_id and is_usable_item(v,bag.id) then
+                --print(i, bag.id)
                 return i, bag.id
             end
         end
@@ -623,6 +628,7 @@ end
 -----------------------------------------------------------------------------------
 function is_usable_item(i_tab,bag_id)
     local ext = extdata.decode(i_tab)
+    --print(i_tab, i_tab.status, bag_id)
     if ext.type == 'Enchanted Equipment' and ext.usable then
         return i_tab.status == 5
     elseif i_tab.status == 0 and bag_id < 4 then

--- a/addons/GearSwap/helper_functions.lua
+++ b/addons/GearSwap/helper_functions.lua
@@ -602,14 +602,10 @@ end
 ---- bag_id - The item's bag ID (if it exists)
 -----------------------------------------------------------------------------------
 function find_usable_item(item_id)
-    --table.vprint(usable_item_bags)
     for _,bag in ipairs(usable_item_bags) do
-        --table.vprint(usable_item_bags)
-        --print(to_windower_bag_api(bag.en), items[to_windower_bag_api(bag.en)])
         for i,v in pairs(items[to_windower_bag_api(bag.en)]) do
             
             if type(v) == 'table' and v.id == item_id and is_usable_item(v,bag.id) then
-                --print(i, bag.id)
                 return i, bag.id
             end
         end
@@ -628,7 +624,6 @@ end
 -----------------------------------------------------------------------------------
 function is_usable_item(i_tab,bag_id)
     local ext = extdata.decode(i_tab)
-    --print(i_tab, i_tab.status, bag_id)
     if ext.type == 'Enchanted Equipment' and ext.usable then
         return i_tab.status == 5
     elseif i_tab.status == 0 and bag_id < 4 then

--- a/addons/GearSwap/helper_functions.lua
+++ b/addons/GearSwap/helper_functions.lua
@@ -604,7 +604,6 @@ end
 function find_usable_item(item_id)
     for _,bag in ipairs(usable_item_bags) do
         for i,v in pairs(items[to_windower_bag_api(bag.en)]) do
-            
             if type(v) == 'table' and v.id == item_id and is_usable_item(v,bag.id) then
                 return i, bag.id
             end

--- a/addons/GearSwap/packet_parsing.lua
+++ b/addons/GearSwap/packet_parsing.lua
@@ -260,9 +260,7 @@ function parse_equip_chunk(chunk)
     end
 end
 
-parse.o[0x037] = function (data,injected) -- Use Item
-    print(injected)
-    print(data)
+parse.o[0x037] = function (data,injected) -- use item
     if gearswap_disabled then return end
     local packet = packets.parse('outgoing', data)
     local item = windower.ffxi.get_items(packet['Bag'], packet['Slot'])

--- a/addons/GearSwap/triggers.lua
+++ b/addons/GearSwap/triggers.lua
@@ -248,11 +248,11 @@ parse.i[0x028] = function (data)
         else
             spell.value = act.targets[1].actions[1].param
         end
-        if ts then --or spell.prefix == '/item' then
+        if ts or spell.prefix == '/item' then
             -- Only aftercast things that were precasted.
             -- Also, there are some actions (like being paralyzed while casting Ninjutsu) that sends two result action packets. Block the second packet.
             refresh_globals()
-            command_registry[ts].midaction = false
+            if ts and command_registry[ts] then command_registry[ts].midaction = false end
             equip_sets(prefix..'aftercast',ts,spell)
         elseif debugging.command_registry then
             msg.debugging('Hitting Aftercast without detecting an entry in command_registry')


### PR DESCRIPTION
Allow (non-interrupted) menu/packet based item use to trigger Aftercast
Also allow menu/packet based item use to trigger Midcast
Checking for interrupted is possible either by tracking multiple `0x028` packets, or by watching for `0x029` message ID 62
