### PR TITLE
Add Engage by ID Feature

### DIFF
--- a/addons/GearSwap/triggers.lua
+++ b/addons/GearSwap/triggers.lua
@@ -51,6 +51,13 @@ windower.register_event('outgoing text',function(original,modified,blocked,ffxi,
     if splitline.n == 0 then return end
 
     local command = splitline[1]
+    if ffxi and command:startswith('/attack') then
+        local match = windower.regex.match(original:lower(), '^\/attack *( on|off)? +([0-9]+) *$') --"/attackoff" exists but "/attackon" doesn't
+        if match and match[1] and match[1][2] then
+            engage_by_id(match[1][2], match[1][1]:trim())
+            return true
+        end
+    end
     local bstpet = command == '/bstpet'
     local unified_prefix = unify_prefix[command]
     local abil, temptarg, temp_mob_arr


### PR DESCRIPTION
## Engage by ID
This pull request adds an engage by ID feature to the GearSwap core, allowing players to engage more freely.

### Safeguards
This feature prevents the following:
1. It only a functions while the player is idle or engaged _(can't be dead, on a chocobo, fishing, etc)_
2. It does nothing if given an invalid ID _(cannot find, no index, valid_target is false)_
3. It does not function while charmed
4. It does not engage/switch-target a mob if the player is already engaged to
5. It does not produce a disengagement packet if the player is already disengaged
6. It does not build a packet if unable to assemble all the required information
7. It does not intercept the vanilla attack commands if they lack an ID. _(/attack, /attack on, /attack off, /attackoff)_
8. Interestingly, it filters out the vanilla "Attack" button's "/attack 12345678" command, by utilizing the ffxi variable.


### Commands:
#### **NOTE:** Utilize a method, such as send's \<tid\> to obtain valid mob ids for these commands.
/attack 12345678 - _toggles engagement on the given mob_
/attack on 12345678 - _engages or switches target to the given mob_
/attack off 12345678 - _disengages from the given mob if it is engaged_
/attackoff 12345678 - _disengages from the given mob if it is engages_
~~/attackon 12345678~~ - _omitted, SE did not include this as a base command_

### How to use:
1. **[Direct Targeting]** Create a/multiple alias(es) such as "alias attackonall send @all input /attack on <tid>"
2. **[Subtargeting]** Create a macro such as "/target <stnpc>[newline]/con send @all /attack <laststid>"