### PR TITLE
Adds the texts:draggable() function

### DIFF
--- a/addons/libs/texts.lua
+++ b/addons/libs/texts.lua
@@ -573,6 +573,14 @@ function texts.stroke_alpha(t, alpha)
     meta[t].settings.text.stroke.alpha = alpha
 end
 
+function texts.draggable(t, draggable)
+    if draggable == nil then
+        return meta[t].settings.flags.draggable
+    end
+
+    meta[t].settings.flags.draggable = draggable
+end
+
 -- Returns true if the coordinates are currently over the text object
 function texts.hover(t, x, y)
     if not t:visible() then


### PR DESCRIPTION
Allows users to toggle texts draggable flag post-creation. Previously, due to the lack of this function, this flag could only be passed in with the settings in a texts.new(settings). Now this flag can be toggled at any time via utilizing this function.

TLDR: This function was in images.lua but not texts.lua. Now it's in both.