### PR TITLE
[gearswap] set modified outgoing text to empty string when injecting actions

### DIFF
--- a/addons/GearSwap/triggers.lua
+++ b/addons/GearSwap/triggers.lua
@@ -153,7 +153,7 @@ windower.register_event('outgoing text',function(original,modified,blocked,ffxi,
                     -- The packets created above should not be used.
                     if command_registry[ts].proposed_packet then
                         equip_sets('precast',ts,spell)
-                        return true
+                        return ""
                     end
                 else
                     return equip_sets('pretarget',-1,spell)


### PR DESCRIPTION
Reproduction scenario for when this matters:

//lua unloadall
//lua load gearswap
//lua load shortcuts

Cast "Cure" on yourself through the menu, specifically Cure 1. This also occurs with "Protect" and possibly others. Cure II and Protect II don't seem to be affected.

This will result in two outgoing 0x01A action packets. You can verify this by breakpointing on LSB at https://github.com/LandSandBoat/server/blob/0aabdea4a3ca9bfb68136e9c6f54dc3ade3cd364/src/map/packet_system.cpp#L879 and performing the above steps.

The change in the PR modifies the command text so once it's handled it couldn't end up being handled a second time due to race conditions.