### PR TITLE
[shortcuts] Pass valid commands through if target and command is valid

### DIFF
--- a/addons/shortcuts/shortcuts.lua
+++ b/addons/shortcuts/shortcuts.lua
@@ -290,7 +290,7 @@ function command_logic(original,modified)
             windower.send_command('@input '..lastsent)
             return '',false
         end
-    elseif command2_list[command] then
+    elseif command2_list[command] or (command_list[command] and valid_target(potential_targ)) then
         -- If the submitted command does not require ability interpretation and is fine already, send it out.
         lastsent = ''
         if logging then


### PR DESCRIPTION
I found the real root cause of #2225

Apparently that was being caused by low player IDs, which explains why it would not happen on retail.

Using the menu to use Cure 1 yourself results in a `/magic "Cure" <id>` but shortcuts interpreted that as cure 5 <me> because the player ID I was had was 5.
![image](https://user-images.githubusercontent.com/60417494/195754977-d053417b-861a-46e2-9145-a79439600015.png)

This PR adds a check for a "complete" normal command with a valid target and passes it straight through. Wanted behavior, such as `//cure 5` results in `/ma "cure v" <me>` as expected.
