### PR TITLE
XML: Fixed runtime error if an xml attribute is present on a node

### DIFF
--- a/addons/libs/xml.lua
+++ b/addons/libs/xml.lua
@@ -384,7 +384,7 @@ function classify(tokens, var)
 
             else
                 if mode == 'tag' then
-                    if parsed:last().children:find(function (el) return el.type == 'attribute' and el.name == token end) ~= nil then
+                    if parsed:last().children:find(function (el) return type(el) == "table" and el.type == 'attribute' and el.name == token end) ~= nil then
                         return xml_error('Attribute '..token..' already defined. Multiple assignment not allowed.', line)
                     end
                     name, namespace = get_namespace(token)


### PR DESCRIPTION
If an attribute is present on a node, an error will result. This may occur because the attribute dupe check can receive plain numbers.

Example XML:
```
<?xml version="1.1" ?>
<settings>
	<test foo="bar" blah="abc">value</test>
</settings>
```

Example Script:
```
_addon.name = 'xmlbug'
_addon.version = '1.0'
_addon.author = 'Xabis'

local xml = require('xml')
local test = xml.read("data/settings.xml")
```

Which results in the the following error:
`xmlbug: Lua runtime error: libs/xml.lua:387: "type" is not defined for numbers`

This simple fix makes an additional check to ensure the value type is a table, prior to probing properties on it.