### PR TITLE
[battlemod] support inundation and Costume status effects

### DIFF
--- a/addons/battlemod/parse_action_packet.lua
+++ b/addons/battlemod/parse_action_packet.lua
@@ -221,6 +221,9 @@ function parse_action_packet(act)
                 -- Some messages uses the english log version of the buff
                 if not simplify and log_form_messages:contains(m.message) then
                     m.status = res.buffs[m.param].enl
+                    if m.status == 'Costume' then m.status = 'costumed'
+                    elseif m.status == 'innundated' then m.status = 'inundated'
+                    end
                 end
 
                 -- if m.message == 93 or m.message == 273 then m.status=color_it('Vanish',color_arr['statuscol']) end


### PR DESCRIPTION
This change makes these debuffs display correctly in battlemod when `simplify` is false (they already work when it is true).

Without battlemod:
![costume-stock](https://user-images.githubusercontent.com/1747598/213391308-38a5983b-aac5-4747-9fbb-28949e1ab15c.png)
Before this change:
![costume-before](https://user-images.githubusercontent.com/1747598/213391317-fd9d918a-299f-4551-9064-f2b1ed261720.png)
After this change:
![costume-after](https://user-images.githubusercontent.com/1747598/213391330-c2408d43-aa98-4dc5-9cc0-72596d551136.png)

Without battlemod:
![inundation-stock](https://user-images.githubusercontent.com/1747598/213391373-6b13a555-17c1-448e-bc9f-0795c4da3f6a.png)
After this change:
![inundation-after](https://user-images.githubusercontent.com/1747598/213391386-633f54b7-6bb9-4743-a8d8-87094d6bd9bb.png)


