### PR TITLE
Update fields.lua

### DIFF
--- a/addons/libs/packets/fields.lua
+++ b/addons/libs/packets/fields.lua
@@ -4019,7 +4019,8 @@ types.ability_recast = L{
     {ctype='unsigned short',    label='Duration',           fn=div+{1}},        -- 00
     {ctype='unsigned char',     label='_unknown1',          const=0x00},        -- 02
     {ctype='unsigned char',     label='Recast',             fn=arecast},        -- 03
-    {ctype='unsigned int',      label='_unknown2'}                              -- 04
+    {ctype='signed short',      label='Recast Modifier',}                       -- 04
+    {ctype='unsigned short',    label='_unknown2'}                              -- 06
 }
 
 -- Ability timers


### PR DESCRIPTION
The new field in 0x0119 contains the difference between the base recast of a job ability, and the actual recast as affected by merits/gear/job points.