### PR TITLE
Update gametime.lua to resolve issue with loading on Lightningday

### DIFF
--- a/addons/gametime/gametime.lua
+++ b/addons/gametime/gametime.lua
@@ -320,7 +320,7 @@ function day_change(day)
         dlist = {'4','5','6','7','8','1','2','3'}
     elseif (day == 'Iceday') then
         dlist = {'5','6','7','8','1','2','3','4'}
-    elseif (day == 'Lightningsday') then
+    elseif (day == 'Lightningday') then
         dlist = {'6','7','8','1','2','3','4','5'}
     elseif (day == 'Lightsday') then
         dlist = {'7','8','1','2','3','4','5','6'}


### PR DESCRIPTION
The gametime addon will not load correctly on Lightningday due to a check only looking for the pluralised form.