### PR TITLE
make it possible to access text settings again

### DIFF
--- a/addons/libs/texts.lua
+++ b/addons/libs/texts.lua
@@ -607,6 +607,10 @@ function texts.destroy(t)
     meta[t] = nil
 end
 
+function texts.settings(t)
+    return meta[t].settings
+end
+
 -- Handle drag and drop
 windower.register_event('mouse', function(type, x, y, delta, blocked)
     if blocked then

--- a/addons/pointwatch/pointwatch.lua
+++ b/addons/pointwatch/pointwatch.lua
@@ -203,7 +203,7 @@ windower.register_event('addon command',function(...)
             end
         end
         texts[first_cmd](box,unpack(tab))
-        settings.text_box_settings = box._settings
+        settings.text_box_settings = box.settings()
         config.save(settings)
     elseif first_cmd == 'reload' then
         windower.send_command('lua r pointwatch')


### PR DESCRIPTION
Pointwatch is basically a text box that updates, so I wanted to expose as much functionality as possible. As such, it just directly exposes approved methods of the texts library and was pirating/serializing the metadata in its own settings. Changes you made almost a decade ago broke this, probably not knowingly but to prevent people from doing this because they would run into problems if someone changed the internal workings of the library.

However, wrapping every method of the texts library is almost as much work as just writing your own library that uses the underlying `windower.` functions. Given how stable the texts library is, could we just expose a `.settings()` method at this point (or the old `_settings` property)?