### PR TITLE
[Addon][translate] Fix for allowing blocked messages through

### DIFF
--- a/addons/translate/translate.lua
+++ b/addons/translate/translate.lua
@@ -221,6 +221,7 @@ windower.register_event('incoming chunk',function(id,orgi,modi,is_injected,is_bl
         end
         return true
     end
+    return is_blocked
 end)
 
 function translate_phrase(out_text)


### PR DESCRIPTION
When used in combination with shout-blocking addons (fuckoff, shout_ml, etc.), this addon would let blocked shouts through. This change should resolve that.