### PR TITLE
add user_pcall variant that doesn't throw

### DIFF
--- a/addons/GearSwap/flow.lua
+++ b/addons/GearSwap/flow.lua
@@ -306,7 +306,7 @@ end
 
 
 -----------------------------------------------------------------------------------
---Name: user_pcall(str,val1,val2,exit_funct)
+--Name: user_pcall(str,...)
 --Desc: Calls a user function, if it exists. If not, throws an error.
 --Args:
 ---- str - Function's key in user_env.
@@ -319,6 +319,27 @@ function user_pcall(str,...)
         if type(user_env[str]) == 'function' then
             bool,err = pcall(user_env[str],...)
             if not bool then error('\nGearSwap has detected an error in the user function '..str..':\n'..err) end
+        elseif user_env[str] then
+            msg.addon_msg(123,windower.to_shift_jis(tostring(str))..'() exists but is not a function')
+        end
+    end
+end
+
+
+-----------------------------------------------------------------------------------
+--Name: user_pcall2(str,...)
+--Desc: Calls a user function, if it exists. If not, prints an error and continues.
+--Args:
+---- str - Function's key in user_env.
+-----------------------------------------------------------------------------------
+--Returns:
+---- none
+-----------------------------------------------------------------------------------
+function user_pcall2(str,...)
+    if user_env then
+        if type(user_env[str]) == 'function' then
+            bool,err = pcall(user_env[str],...)
+            if not bool then print('\nGearSwap has detected an error in the user function '..str..':\n'..err) end
         elseif user_env[str] then
             msg.addon_msg(123,windower.to_shift_jis(tostring(str))..'() exists but is not a function')
         end

--- a/addons/GearSwap/refresh.lua
+++ b/addons/GearSwap/refresh.lua
@@ -63,7 +63,7 @@ function load_user_files(job_id,user_file)
     job_id = tonumber(job_id)
 
     if current_file then
-        user_pcall('file_unload',current_file)
+        user_pcall2('file_unload',current_file)
     end
 
     for i in pairs(registered_user_events) do


### PR DESCRIPTION
Tested using your example code and it no longer failed.

test1.lua:
```
print('test1 file')

a = 10

function file_unload()
    print(dummy.lol)
end
```

test2.lua:
```
print('test2 file')

b = 10
```

I toggle between the two using `gs load test1` or `gs load test2`. Can check which file is loaded (or if both are somehow loaded) by toggling `gs debugmode` on and using `gs eval print(user_env.a, user_env.b)`

Before this patch, it fails to unload test1 and `a` always takes a value of 10. After the patch, it does successfully unload test1 and loads test2, so a goes to nil and b goes to 10. Swapping back and forth results in the expected changes.