### PR TITLE
Addon: Shortcuts

### DIFF
--- a/addons/shortcuts/shortcuts.lua
+++ b/addons/shortcuts/shortcuts.lua
@@ -220,7 +220,7 @@ function command_logic(original,modified)
     local a,b,spell = string.find(original,'"(.-)"')
 
     -- If user is attempting to use the default item command stop.
-    if original:match("item [\"\'][%a\':-.]+[\"\'] [<][%a]+[>]") then
+    if original:match("item [\"\'][%a%s\':-.]+[\"\'] .+") then
         return false
     end
     

--- a/addons/shortcuts/shortcuts.lua
+++ b/addons/shortcuts/shortcuts.lua
@@ -218,6 +218,11 @@ function command_logic(original,modified)
         potential_targ = splitline[splitline.n]
     end
     local a,b,spell = string.find(original,'"(.-)"')
+
+    -- If user is attempting to use the default item command stop.
+    if original:match("item [\"\'][%a\':-.]+[\"\'] [<][%a]+[>]") then
+        return false
+    end
     
     if unhandled_list[command] then
         return modified,true


### PR DESCRIPTION
If a user attempts to use the default in-game item command, shortcuts attempts to cast a spell if the spell and item name are the same.

Block shortcuts from finishing command logic if it detects default item command method.
![image](https://github.com/Windower/Lua/assets/56209868/c94a9cef-6127-4879-b9fa-5f19fbddec00)
