### PR TITLE
[gearswap] Update export.lua

### DIFF
--- a/addons/GearSwap/README.md
+++ b/addons/GearSwap/README.md
@@ -1,6 +1,6 @@
 Author: Byrth
 
-Version: 0.930
+Version: 0.938
 
 Date: 06/13/2017
 
@@ -9,27 +9,33 @@ GearSwap
 Abbreviation: gs
 
 Commands (<> indicates a field. You do not actually have to use <>s):
-* gs c <string> : Passes the <string> to the self_command() user function.
-* gs equip <string> : Attempts to interpret the <string> as an index of the sets table and equip that set. Will ignore "sets" if the string starts with it.
+* gs c \<string\> : Passes the <string> to the self_command() user function.
+* gs equip \<string\> : Attempts to interpret the <string> as an index of the sets table and equip that set. Will ignore "sets" if the string starts with it.
 ** gs equip naked : This equips the default set "naked," which is just a bunch of empty slots. If you remake sets (sets={}) in your get_sets(), this will not work.
 * gs debugmode : Activates GearSwap's Debug Mode, which prints out why specific gear equipping attempts failed, shows you when you're entering events, and enables the eval command.
-** gs eval <string> : This command evaluates the <string> as Lua code in the global gearswap environment (not the user environment, which is in the user_env table). It is only available when debugmode is on.
+** gs eval \<string\> : This command evaluates the <string> as Lua code in the global gearswap environment (not the user environment, which is in the user_env table). It is only available when debugmode is on.
 * gs showswaps : Shows when your gear successfully changes and what it changes to.
-* gs load <string> : (or l <string>) Attempts to load the first version of <string> found, assuming it is a file path relative to 9 potential base directories, in this order:
-** ..GearSwap/libs-dev/<string>
-** ..GearSwap/libs/<string>
-** GearSwap/data/<character_name>/<string>
-** GearSwap/data/common/<string>
-** GearSwap/data/<string>
-** APPDATA/Windower/GearSwap/<character_name>/<string>
-** APPDATA/Windower/GearSwap/common/<string>
-** APPDATA/Windower/GearSwap/<string>
-** ..Windower/addons/libs/<string>
+* gs load \<string\> : (or l <string>) Attempts to load the first version of <string> found, assuming it is a file path relative to 9 potential base directories, in this order:
+   * ..GearSwap/libs-dev/\<string\>
+   * ..GearSwap/libs/\<string\>
+   * GearSwap/data/\<character_name\>/\<string\>
+   * GearSwap/data/common/\<string\>
+   * GearSwap/data/\<string\>
+   * APPDATA/Windower/GearSwap/\<character_name\>/\<string\>
+   * APPDATA/Windower/GearSwap/common/\<string\>
+   * APPDATA/Windower/GearSwap/\<string\>
+   * ..Windower/addons/libs/\<string\>
 * gs reload : Reloads the current user file.
-* gs export <options> : Exports your currently equipped gear, inventory, or all the items in your current Lua files' sets into GearSwap .lua or spellcast .xml format. Takes options "inventory", "all", "wearable", "sets", and "xml." Defaults to currently equipped gear and lua otherwise. Also exports appropriate advanced set tables with augments for currently equipped gear and inventory.
-* gs enable <slot> : Enables equip commands targeting a specified slot. "All" will allow all equip commands. Providing no slot argument will enable user GearSwap file execution, if it was disabled.
-* gs disable <slot> : Disables equip commands targeting a given slot. "All" will prevent all equip commands. Providing no second argument will disable user GearSwap file execution, although registered events will still run.
-* gs validate <sets|inv> <filter> : This command checks to see whether the equipment in the sets table also exists in your inventory (default), or (by passing "inv") whether the equipment in your inventory exists in your sets table. <filter> is an optional list of words that restricts the output to only those items that contain text from one of the filter's words.
+* gs export \<options\> : Exports your currently equipped gear, inventory, or all the items in your current Lua files' sets into GearSwap .lua format.
+   Available options: 
+   * one of "inventory", "all", "wearable", "sets". Defaults to currently equipped gear and lua otherwise.
+   * "noaugments", to export only base names and omit augments, or "only augments"m to export only gear that is augmented. These two options are mutually exclusive. Defaults to exporting all gear with the respective augments (if present) if neither is specified.
+   *  "minify", exports the set in a single line without newlines.
+   * "clipboard", exports the set to clipboard instead of a file.
+   * "filename", followed by the desired name, exports to the specified filename. Defaults to "Charactername_YYYY-MM-DD HH:MM:SS.lua" otherwise. Does nothing if "clipboard" is passed.
+* gs enable \<slot\> : Enables equip commands targeting a specified slot. "All" will allow all equip commands. Providing no slot argument will enable user GearSwap file execution, if it was disabled.
+* gs disable \<slot\> : Disables equip commands targeting a given slot. "All" will prevent all equip commands. Providing no second argument will disable user GearSwap file execution, although registered events will still run.
+* gs validate \<sets|inv\> \<filter\> : This command checks to see whether the equipment in the sets table also exists in your inventory (default), or (by passing "inv") whether the equipment in your inventory exists in your sets table. \<filter\> is an optional list of words that restricts the output to only those items that contain text from one of the filter's words.
 
 Purpose: To assist in the micromanaging of equipment!
 

--- a/addons/GearSwap/export.lua
+++ b/addons/GearSwap/export.lua
@@ -24,83 +24,106 @@
 --(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 --SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+
 function export_set(options)
-    local named_file = false
-    local filename = false
-    for i=1,#options do
-        if S{'filename','file','f'}:contains(options[i]) then
-            filename = table.remove(options,i+1)
-            if not filename then
-                msg.addon_msg(123,'Cannot export to named file because a filename was not provided.')
-                return
-            end
-            named_file = table.remove(options,i)
-            break
-        end
-    end
-
-    local options = S(options):map(string.lower)
-
-    local targinv = not (options* S{'inventory','inv','i'}):empty()
-    local all_items = options:contains('all')
-    local wearable = options:contains('wearable')
-    local all_sets = not (options * S{'sets','set','s'}):empty()
-    if all_sets and (not user_env or not user_env.sets) then
-        msg.addon_msg(123,'Cannot export the sets table of the current file because there is no file loaded.')
+    local filename_index = table.find(options, set.contains+{S{'filename', 'file', 'f'}})
+    local filename = filename_index ~= nil and options[filename_index+1]
+    if filename_index and not filename then
+        msg.addon_msg(123, 'Cannot export to named file because a filename was not provided.')
         return
     end
 
-    local noaugments = not (options * S{'noaugments','noaugs'}):empty()
-    if noaugments then onlyaugmented = false end
+    local setname_index = table.find(options, set.contains+{S{'setname', 'name', 'n'}})
+    local setname = setname_index ~= nil and options[setname_index+1]
+    if setname_index and not setname then
+        msg.addon_msg(123, 'Cannot export to named set because a set name was not provided.')
+        return
+    end
 
-    local onlyaugmented = not (options * S{'onlyaugmented','onlyaugs'}):empty()
-    if onlyaugmented then noaugments = false end
+    local options = S(options):map(string.lower)
+    local contains_any = function(...) return not (options * S{...}):empty() end
+    local check_exclusive = function(...) return #T{...}:filter(true) > 1 end
 
-    local minify = not (options * S{'mini','minify'}):empty()
-    local clipboard = not (options * S{'copy','clipboard'}):empty()
-    local use_job_in_filename = options:contains('mainjob')
-    local use_subjob_in_filename = options:contains('mainsubjob')
-    local overwrite_existing = options:contains('overwrite')
+    local targinv = contains_any('inventory', 'inv', 'i')
+    local all_items = contains_any('all')
+    local wearable = contains_any('wearable')
+    local all_sets = contains_any('sets', 'set', 's')
+    if all_sets and (not user_env or not user_env.sets) then
+        msg.addon_msg(123, 'Cannot export the sets table of the current file because there is no file loaded.')
+        return
+    end
+
+    local noaugments = contains_any('noaugments', 'noaugs')
+    local onlyaugmented = contains_any('onlyaugmented', 'onlyaugs')
+    if check_exclusive(noaugments, onlyaugmented) then
+        msg.addon_msg(123, 'Cannot export: "noaugments" and "onlyaugmented" are mutually exclusive.')
+        return
+    end
+
+    local minify = contains_any('mini', 'minify')
+
+    local compact = contains_any('compact')
+    local bgwiki = contains_any('bgwiki')
+    if check_exclusive(compact) then
+        msg.addon_msg(123, 'Cannot export: "compact" and "bgwiki" are mutually exclusive.')
+        return
+    end
+
+    local filename = filename
+    local clipboard = contains_any('copy', 'clipboard')
+    local use_job_in_filename = contains_any('mainjob')
+    local use_subjob_in_filename = contains_any('mainsubjob')
+    if check_exclusive(filename, clipboard, use_job_in_filename, use_subjob_in_filename) then
+        msg.addon_msg(123, 'Cannot export: "filename", "clipboard", "use_job_in_filename", and "use_subjob_in_filename" are mutually exclusive.')
+        return
+    end
+
+    local overwrite_existing = contains_any('overwrite') or nil
 
     local buildmsg = 'Exporting '
     if all_items then
-        buildmsg = buildmsg..'all your items'
+        buildmsg = buildmsg .. 'all your items'
     elseif wearable then
-        buildmsg = buildmsg..'all your items in inventory and wardrobes'
+        buildmsg = buildmsg .. 'all your items in inventory and wardrobes'
     elseif targinv then
-        buildmsg = buildmsg..'your current inventory'
+        buildmsg = buildmsg .. 'your current inventory'
     elseif all_sets then
-        buildmsg = buildmsg..'your current sets table'
+        buildmsg = buildmsg .. 'your current sets table'
     else
-        buildmsg = buildmsg..'your currently equipped gear'
+        buildmsg = buildmsg .. 'your currently equipped gear'
     end
 
     if noaugments then
-        buildmsg = buildmsg..' (omitting augments)'
+        buildmsg = buildmsg .. ' (omitting augments)'
     elseif onlyaugmented then
-        buildmsg = buildmsg..' (only augmented items)'
+        buildmsg = buildmsg .. ' (only augmented items)'
+    end
+
+    if compact then
+        buildmsg = buildmsg .. ' in compact format'
+    elseif bgwiki then
+        buildmsg = buildmsg .. ' in BG-Wiki Template format'
     end
 
     if clipboard then
-        buildmsg = buildmsg..' to clipboard.'
+        buildmsg = buildmsg .. ' to clipboard.'
     else
-        buildmsg = buildmsg..' as a lua file.'
+        buildmsg = buildmsg .. ' as a lua file.'
 
-        if use_job_in_filename then
-            buildmsg = buildmsg..' (Naming format: Character_JOB)'
+        if filename then
+            buildmsg = buildmsg .. ' (Named: Character_'..filename..')'
+        elseif use_job_in_filename then
+            buildmsg = buildmsg .. ' (Naming format: Character_JOB)'
         elseif use_subjob_in_filename then
-            buildmsg = buildmsg..' (Naming format: Character_JOB_SUB)'
-        elseif named_file then
-            buildmsg = buildmsg..' (Named: Character_'..filename..')'
+            buildmsg = buildmsg .. ' (Naming format: Character_JOB_SUB)'
         end
 
         if overwrite_existing then
-            buildmsg = buildmsg..' Will overwrite existing files with same name.'
+            buildmsg = buildmsg .. ' Will overwrite existing files with same name.'
         end
     end
 
-
-    msg.addon_msg(123,buildmsg)
+    msg.addon_msg(123, buildmsg)
 
     local item_list = T{}
     if all_items then
@@ -115,7 +138,7 @@ function export_set(options)
         item_list:extend(get_item_list(items.inventory))
     elseif all_sets then
         -- Iterate through user_env.sets and find all the gear.
-        item_list,exported = unpack_names({},'L1',user_env.sets,{},{empty=true})
+        item_list,exported = unpack_names({}, 'L1', user_env.sets,{},{empty=true})
     else
         -- Default to loading the currently worn gear.
 
@@ -137,11 +160,11 @@ function export_set(options)
                         name = res.items[item_tab.id][language],
                         slot = slot_name
                         }
-                    if not noaugments then
+                    if not noaugments and not res.items[item_tab.id].flags:contains('Rare') then
                         local augments = extdata.decode(item_tab).augments or {}
                         local aug_str = ''
                         for aug_ind,augment in pairs(augments) do
-                            if augment ~= 'none' then aug_str = aug_str.."'"..augment:gsub("'","\\'").."'," end
+                            if augment ~= 'none' then aug_str = aug_str .. "'"..augment:gsub("'","\\'") .. "'," end
                         end
                         if string.len(aug_str) > 0 then
                             item_list[slot_map[slot_name]+1].augments = aug_str
@@ -155,7 +178,7 @@ function export_set(options)
     end
 
     if #item_list == 0 then
-        msg.addon_msg(123,'There is nothing to export.')
+        msg.addon_msg(123, 'There is nothing to export.')
         return
     else
         local not_empty
@@ -166,51 +189,119 @@ function export_set(options)
             end
         end
         if not not_empty then
-            msg.addon_msg(123,'There is nothing to export.')
+            msg.addon_msg(123, 'There is nothing to export.')
             return
         end
     end
 
-    local output = 'sets.exported={\n'
-
     local newline = minify and '' or '\n'
-    for i,v in ipairs(item_list) do
-        if v.name ~= empty then
-            if v.augments then
-                --Advanced set table
-                output = output .. '    '..v.slot..'={ name="'..v.name..'", augments={'..v.augments..'}},'..newline
-            elseif not onlyaugmented then
-                output = output .. '    '..v.slot..'="'..v.name..'",'..newline
+
+    local output
+    if setname then
+        output = 'sets["' .. setname .. '"] = {' .. newline
+    else
+        output = 'sets.exported = {' .. newline
+    end
+
+    if compact then
+        local slots_order = {
+            { "main", "sub", "range", "ammo" },
+            { "head", "neck", "left_ear", "right_ear" },
+            { "body", "hands", "left_ring", "right_ring" },
+            { "back", "waist", "legs", "feet" },
+        }
+
+        local item_list = item_list:rekey('slot')
+
+        for _, row in ipairs(slots_order) do
+            local line = {}
+
+            for _, slot in ipairs(row) do
+                local v = item_list[slot]
+
+                if v and v.name ~= empty then
+                    if v.augments then
+                        --Advanced set table
+                        table.insert(line, slot..'={ name="'..v.name..'", augments={'..v.augments..'}},')
+                    elseif not onlyaugmented then
+                        table.insert(line, slot..'="'..v.name..'",')
+                    end
+                end
+            end
+
+            if #line > 0 then
+                output = output .. "    " .. table.concat(line, " ") .. newline
+            end
+        end
+
+    elseif bgwiki then
+        local wikiformat = {
+            ['left_ear'] = 'Ear1', ['right_ear'] = 'Ear2',
+            ['left_ring'] = 'Ring1', ['right_ring'] = 'Ring2',
+        }
+
+        output = "{{Guide Equipment Set\n|Set Name Background=\n|Set Name Text Color=\n|Set Name Text Shadow=\n"
+        output = output .. "|Set Name=%s\n|Set Border Color=\n":format(setname or 'Exported')
+        output = output .. "|Equipment Set = Exported by %s on %s\n":format(player.name, os.date(' %Y-%m-%d %H-%M-%S'))
+        output = output .. "{{Equipment Set\n|CaptionTop = %s\n|CaptionBottom = Exported\n":format(setname or 'Exported')
+
+        for i,v in ipairs(item_list) do
+            if v.name ~= empty then
+                local slot = v.slot:gsub('.*', wikiformat):ucfirst()
+
+                output = output .. '| %s = %s\n':format(slot, v.name)
+                if v.augments then
+                    local augments = v.augments:gsub("[%'%\"]","%1")
+                    output = output .. '| %sAug = %s\n':format(slot, augments)
+                end
+            end
+        end
+
+        output = output .. "|List = y\n|Background = \n}}\n|Equipment Set Notes =\n}"
+
+    else
+        for i,v in ipairs(item_list) do
+            if v.name ~= empty then
+                if v.augments then
+                    --Advanced set table
+                    output = output .. '    %s={ name="%s", augments={%s}},':format(v.slot, v.name, v.augments)
+                    -- output = output .. '    '..v.slot..'={ name="'..v.name..'", augments={'..v.augments..'}},'
+                elseif not onlyaugmented then
+                    output = output .. '    %s="%s",':format(v.slot, v.name)
+                    -- output = output .. '    '..v.slot..'="'..v.name..'",'
+                end
+                output = output .. newline
             end
         end
     end
+
     output = output .. '}'
 
     if clipboard then
         windower.copy_to_clipboard(output)
     else
 
-        if not windower.dir_exists(windower.addon_path..'data/export') then
-            windower.create_dir(windower.addon_path..'data/export')
+        if not windower.dir_exists(windower.addon_path .. 'data/export') then
+            windower.create_dir(windower.addon_path .. 'data/export')
         end
 
-        local path = windower.addon_path..'data/export/'..player.name
+        local path = windower.addon_path .. 'data/export/' .. player.name
 
         if use_job_in_filename then
-            path = path..'_'..windower.ffxi.get_player().main_job
+            path = path .. '_' .. windower.ffxi.get_player().main_job
         elseif use_subjob_in_filename then
-            path = path..'_'..windower.ffxi.get_player().main_job..'_'..windower.ffxi.get_player().sub_job
-        elseif named_file then
-            path = path..'_'..filename
+            path = path .. '_' .. windower.ffxi.get_player().main_job .. '_' .. windower.ffxi.get_player().sub_job
+        elseif filename then
+            path = path .. '_' .. filename
         else
-            path = path..os.date(' %Y-%m-%d %H-%M-%S')
+            path = path .. os.date(' %Y-%m-%d %H-%M-%S')
         end
 
-        if (not overwrite_existing) and windower.file_exists(path..'.lua') then
-            path = path..' '..os.clock()
+        if (not overwrite_existing) and windower.file_exists(path .. '.lua') then
+            path = path .. ' ' .. os.clock()
         end
 
-        local f = io.open(path..'.lua','w+')
+        local f = io.open(path .. '.lua', 'w+')
         f:write(output)
         f:close()
     end


### PR DESCRIPTION
Removed some code duplication and reordered some other code.

Added a new `copy`/`clipboard` flag, which makes GS export the table to clipboard instead of to a file.

INPUT NEEDED:
I also added two new flags, `noaugments` and `onlyaugmented` which respectively do:
- `noaugments`/`noaugs` exports the set without recording the augments on each item. Useful if you mostly have single-path items so you don't get a spam of `augments={'Path: A'}` and such; or if you already have augmented items saved.
- `onlyaugmented`/`onlyaugs` *only* exports items that have augments and ignores entirely non-augmented items. Useful if you need to make variables for your augmented gear, or in combination with the `wearable` flag to export all augmented items that your current job can equip, to make a new gearswap file, etc.

The issue I have is that I would like gearswap to print out a notice when provided one of these flags, but I can't come up with good ones myself 😄 input appreciated