### PR TITLE
(Send) Added string interpolation support

### DIFF
--- a/addons/libs/packets/fields.lua
+++ b/addons/libs/packets/fields.lua
@@ -1296,7 +1296,7 @@ fields.incoming[0x00A] = L{
     {ctype='signed short',      label='DEX'},                                   -- CE
     {ctype='signed short',      label='VIT'},                                   -- D0
     {ctype='signed short',      label='AGI'},                                   -- D2
-    {ctype='signed short',      label='IND'},                                   -- F4
+    {ctype='signed short',      label='INT'},                                   -- F4
     {ctype='signed short',      label='MND'},                                   -- D6
     {ctype='signed short',      label='CHR'},                                   -- D8
     {ctype='signed short',      label='STR Bonus'},                             -- DA

--- a/addons/send/readme.md
+++ b/addons/send/readme.md
@@ -26,3 +26,12 @@ Examples:
 /ta <stnpc>
 //send Mymule /ma "Blizzard" <laststid>
 ```
+
+## Sending dynamic values
+
+Dynamic values can be sent to the receiver by using custom Lua tokens in the format ${lua code here}.
+
+Examples:
+```
+//send @party /p Hi, my name is ${windower.ffxi.get_player().name}!
+```

--- a/addons/send/send.lua
+++ b/addons/send/send.lua
@@ -32,6 +32,18 @@ windower.register_event('addon command', function(target, ...)
     end):sconcat():gsub('<(%a+)id>', function(target_string)
         local entity = windower.ffxi.get_mob_by_target(target_string)
         return entity and entity.id or '<' .. target_string .. 'id>'
+    end):gsub('%${(.-)}', function(target_string)
+        if not target_string then
+            error("Lua tokens must contain a valid Lua string to evaluate")
+        elseif target_string:sub(1, 6) ~= "return" then
+            target_string = "return "..target_string
+        end
+        local func = assert(loadstring(target_string), "The Lua string provided is invalid")
+        local success, result = pcall(func)
+        if not success then
+            error("Lua token evaluation failed. "..tostring(result))
+        end
+        return result and tostring(result) or ""
     end)
 
     local player = windower.ffxi.get_player()


### PR DESCRIPTION
In certain cases it is necessary to send dynamic values through the Send addon. In order to support those values, I added String interpolation support that allows a Send user to input Lua into a Javascript template literal token format and have that evaluated at runtime. Javascript template literal token format was chosen because it is unlikely that players have existing alias and macros that use ${}, whereas formats like {}, (), or [] may be more common.

Example use:
`send @party /p Hi, my name is ${windower.ffxi.get_player().name}`
Results in all players in a party saying in party chat "Hi, my name is " and their character name

