### PR TITLE
[GearSwap] Update helper_functions.lua

### DIFF
--- a/addons/GearSwap/helper_functions.lua
+++ b/addons/GearSwap/helper_functions.lua
@@ -1072,10 +1072,12 @@ function spell_complete(rline)
     end
 
     if rline.skill and tonumber(rline.skill) then
+        rline.skill_id = rline.skill
         rline.skill = res.skills[rline.skill][language]
     end
 
     if rline.element and tonumber(rline.element) then
+        rline.element_id = rline.element
         rline.element = res.elements[rline.element][language]
     end
 


### PR DESCRIPTION
Preserve IDs for spell.skill and spell.element as they're potentially useful in multiple scenarios, most often when comparing stuff against resources