### PR TITLE
[Trusts] Fix Cornelia ID

### DIFF
--- a/addons/Trusts/Trusts.lua
+++ b/addons/Trusts/Trusts.lua
@@ -367,7 +367,7 @@ trusts = T{
     [117]={id=1017,japanese="アシェラII",english="Arciela II",name="Arciela",models=3085},
     [118]={id=1018,japanese="イロハII",english="Iroha II",name="Iroha",models=3112},
     [119]={id=1019,japanese="シャントットII",english="Shantotto II",name="Shantotto",models=3110},
-    [120]={id=1003,japanese="コーネリア",english="Cornelia",name="Cornelia",models=3119}, --goodbye, my love
+    [120]={id=1002,japanese="コーネリア",english="Cornelia",name="Cornelia",models=3119}, --goodbye, my love
     [121]={id=999,japanese="モンブロー",english="Monberaux",name="Monberaux",models=3120},
     [122]={id=1003,japanese="マツイP",english="Matsui-P",name="Matsui-P",models=3121},
 }


### PR DESCRIPTION
Cornelia's spell id in spells.lua is 102, just fixing it here now that she's back for a bit.