### PR TITLE
[gearswap] Parse last_incoming packets in chronological order.

### DIFF
--- a/addons/GearSwap/gearswap.lua
+++ b/addons/GearSwap/gearswap.lua
@@ -25,7 +25,7 @@
 --SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 _addon.name = 'GearSwap'
-_addon.version = '0.937'
+_addon.version = '0.938'
 _addon.author = 'Byrth'
 _addon.commands = {'gs','gearswap'}
 

--- a/addons/GearSwap/packet_parsing.lua
+++ b/addons/GearSwap/packet_parsing.lua
@@ -758,24 +758,22 @@ parse.o[0x100] = function(data)
 end
 
 
-function initialize_packet_parsing()
-    local packets_queue = {}
-    local packets_order = {}
 
-    for i,v in pairs(parse.i) do
+function initialize_packet_parsing()
+    local lastpackets = L{}
+    
+    for i,_ in pairs(parse.i) do
         if i ~= 0x028 then
-            local p, ts = windower.packets.last_incoming(i)
-            if p then
-                packets_queue[ts] = { id = i, data = p }
-                packets_order[#packets_order +1] = ts
+            local data, ts = windower.packets.last_incoming(i)
+            if data then
+                lastpackets:append({ id = i, ts = ts, data = data })
             end
         end
     end
     
-    table.sort(packets_order)
+    table.sort(lastpackets, function(t1, t2) return t1.ts < t2.ts end)
     
-    for _,ts in ipairs(packets_order) do
-        local p = packets_queue[ts]
+    for _,p in ipairs(lastpackets) do
         parse.i[p.id](p.data)
     end
 end

--- a/addons/GearSwap/packet_parsing.lua
+++ b/addons/GearSwap/packet_parsing.lua
@@ -757,16 +757,25 @@ parse.o[0x100] = function(data)
     end
 end
 
+
 function initialize_packet_parsing()
+    local packets_queue = {}
+    local packets_order = {}
+
     for i,v in pairs(parse.i) do
         if i ~= 0x028 then
-            local lastpacket = windower.packets.last_incoming(i)
-            if lastpacket then
-                v(lastpacket)
-            end
-            if i == 0x63 and lastpacket and lastpacket:byte(5) ~= 9 then
-                -- Not receiving an accurate buff line on load because the wrong 0x063 packet was sent last
+            local p, ts = windower.packets.last_incoming(i)
+            if p then
+                packets_queue[ts] = { id = i, data = p }
+                packets_order[#packets_order +1] = ts
             end
         end
+    end
+    
+    table.sort(packets_order)
+    
+    for _,ts in ipairs(packets_order) do
+        local p = packets_queue[ts]
+        parse.i[p.id](p.data)
     end
 end


### PR DESCRIPTION
Previously gearswap would present stale player data right upon loading, due to reading last_incoming packets out of chronological order. This commit fixes that.