### PR TITLE
[gearswap] Fix issue with packet initialization.

### DIFF
--- a/addons/GearSwap/gearswap.lua
+++ b/addons/GearSwap/gearswap.lua
@@ -25,7 +25,7 @@
 --SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 _addon.name = 'GearSwap'
-_addon.version = '0.938'
+_addon.version = '0.939'
 _addon.author = 'Byrth'
 _addon.commands = {'gs','gearswap'}
 
@@ -131,6 +131,7 @@ require 'flow'
 require 'triggers'
 
 initialize_packet_parsing()
+gearswap_disabled = false
 
 windower.register_event('load',function()
     windower.debug('load')

--- a/addons/GearSwap/statics.lua
+++ b/addons/GearSwap/statics.lua
@@ -177,7 +177,7 @@ slot_map.back = 15
 
 
 
-gearswap_disabled = false
+gearswap_disabled = true
 seen_0x063_type9 = false
 delay_0x063_v9 = false
 vana_offset = 572662306+1009810800


### PR DESCRIPTION
Partially reverts #2026. 

Previously, gearswap would be disabled by default during addon load, and only be enabled once an userprofile was loaded.
A side effect of this was that the ability of gearswap to enable game commands with a numeric ID for a target (i.e. `/ma "Fire V" 123456`) was disabled without an userprofile loaded.
#2026 was meant to address this, but in the meantime it broke a bunch of functions that relied on the disabled flag to be aware that gearswap was being loaded.

This change fixes the issue by making `gearswap_disabled = true` on load again, and setting it to `false` as desired only once all the addon components have been loaded and the packet information has been fully parsed, solving the issue entirely.