### PR TITLE
Libs/Strings: Fix Shift-JIS character code range

### DIFF
--- a/addons/libs/strings.lua
+++ b/addons/libs/strings.lua
@@ -109,9 +109,10 @@ do
             [string.encoding.shift_jis] = function(str, from, to)
                 return process(str, from, to, function(byte)
                     return
-                        (byte < 0x80 or byte >= 0xA1 and byte <= 0xDF) and 1 or
-                        (byte >= 0x1E and byte <= 0x1F or byte >= 0x80 and byte <= 0x9F or byte >= 0xE0 and byte <= 0xEF or byte >= 0xFA and byte <= 0xFC) and 2 or
-                        byte == 0xFD and 6
+                        byte == 0xFD and 6 or
+                        ((byte >= 0x81 and byte <= 0x9F) or (byte >= 0xE0 and byte <= 0xEF)) and 2 or
+                        (byte < 0x80 or (byte >= 0x40 and byte <= 0x7E) or (byte >= 0x80 and byte <= 0xFC)) and 1 or
+                        nil
                 end)
             end,
             [string.encoding.binary] = function(str, from, to)


### PR DESCRIPTION
There is an issue with the Shift-JIS iterator definition in libs/strings.lua where it cannot iterate correctly when characters with a second byte in the range of 0xF0–0xF9 are included in the string.

The ranges for the first and second bytes in Shift-JIS are as follows:

First byte: 0x81–0x9F, 0xE0–0xEF
Second byte: 0x40–0x7E, 0x80–0xFC
Strictly speaking, there are some unmapped characters within these ranges, but for the purposes of determining how many bytes to advance for iteration (rather than for character mapping), these ranges should be sufficient.

I have modified the condition to perform checks within these defined ranges.

You can verify this by running a Lua script like the following:
```
require 'strings'
str = "abc" .. string.char(0x081,0x0F4) .. "def" -- "abc♪def"
windower.send_command('input /echo ' .. str)
pattern = string.char(0x081,0x0F4)
i, j = str:find(pattern, string.encoding.shift_jis, 1)
print(i, j)
i, j = str:find(pattern, string.encoding.shift_jis, 5) -- error
print(i, j)
```