### PR TITLE
Lili ffxi batch buff refresh

### DIFF
--- a/addons/GearSwap/packet_parsing.lua
+++ b/addons/GearSwap/packet_parsing.lua
@@ -31,9 +31,6 @@ parse = {
 
 parse.i[0x00A] = function (data)
     windower.debug('zone change')
-    
-    -- print('gearswap_disabled during lastincoming',gearswap_disabled)
-    
     command_registry = Command_Registry.new()
     table.clear(not_sent_out_equip)
 
@@ -776,7 +773,6 @@ function initialize_packet_parsing()
     end
     
     table.sort(lastpackets, function(t1, t2) return t1.ts < t2.ts end)
-
     for _,p in ipairs(lastpackets) do
         parse.i[p.id](p.data)
     end

--- a/addons/GearSwap/packet_parsing.lua
+++ b/addons/GearSwap/packet_parsing.lua
@@ -31,6 +31,9 @@ parse = {
 
 parse.i[0x00A] = function (data)
     windower.debug('zone change')
+    
+    -- print('gearswap_disabled during lastincoming',gearswap_disabled)
+    
     command_registry = Command_Registry.new()
     table.clear(not_sent_out_equip)
 
@@ -518,10 +521,7 @@ parse.i[0x063] = function (data)
                     end
                     local buff_name = res.buffs[new.id][language]
                     windower.debug('refresh buff '..buff_name..' ('..tostring(new.id)..')')
-                    if not gearswap_disabled then
-                        refresh_globals()
-                        equip_sets('buff_refresh',nil,buff_name,new)
-                    end
+                    batch:append({name=buff_name,refresh=true,tab=new})                    
                 else
                     -- Not matched, so it's assumed the buff is new
                     if not res.buffs[new.id] then
@@ -556,7 +556,11 @@ parse.i[0x063] = function (data)
             if not gearswap_disabled and #batch > 0 then
                 refresh_globals()
                 for v,_ in batch:it() do
-                    equip_sets('buff_change',nil,v.name,v.gain,v.tab)
+                    if v.refresh then
+                        equip_sets('buff_refresh',nil,v.name,v.tab)
+                    else
+                        equip_sets('buff_change',nil,v.name,v.gain,v.tab)
+                    end
                 end
             end
         end
@@ -772,7 +776,7 @@ function initialize_packet_parsing()
     end
     
     table.sort(lastpackets, function(t1, t2) return t1.ts < t2.ts end)
-    
+
     for _,p in ipairs(lastpackets) do
         parse.i[p.id](p.data)
     end


### PR DESCRIPTION
#2265 changed the way buffs are parsed so that multiple buffs gained/removed in a single packet would be processed in batch, refreshing globals only once. This PR extends the batch to the buffs that refresh, since in certain circumstances gaining a new buff causes the server to send a refresh for _all_ buffs currently on the player, causing stutter.