### PR TITLE
[GearSwap] Differentiate between item usage on NPCs versus player.

### DIFF
--- a/addons/GearSwap/statics.lua
+++ b/addons/GearSwap/statics.lua
@@ -131,7 +131,7 @@ addendum_black = {[253]="Sleep",[259]="Sleep II",[260]="Dispel",[162]="Stone IV"
     [168]="Thunder V",[157]="Aero IV",[158]="Aero V",[152]="Blizzard IV",[153]="Blizzard V",[147]="Fire IV",[148]="Fire V",
     [172]="Water IV",[173]="Water V",[255]="Break"}
 
-resources_ranged_attack = {id="0",index="0",prefix="/range",english="Ranged",german="Fernwaffe",french="Attaque à dist.",japanese="飛び道具",type="Misc",element="None",targets=S{"Enemy"}}
+resources_ranged_attack = {id="0",index="0",prefix="/range",range=25,english="Ranged",german="Fernwaffe",french="Attaque à dist.",japanese="飛び道具",type="Misc",element="None",targets=S{"Enemy"}}
 
 
 -- _globals --

--- a/addons/GearSwap/triggers.lua
+++ b/addons/GearSwap/triggers.lua
@@ -120,6 +120,7 @@ windower.register_event('outgoing text',function(original,modified,blocked,ffxi,
                 storedcommand = command..' "'..windower.to_shift_jis(r_line[language])..'" '
             elseif unified_prefix == '/ra' then
                 r_line = copy_entry(resources_ranged_attack)
+                r_line.range = '25' -- temp
                 storedcommand = command..' '
             end
             
@@ -137,6 +138,7 @@ windower.register_event('outgoing text',function(original,modified,blocked,ffxi,
                         -- Item use packet handling here
                         if bit.band(spell.target.spawn_type, 2) == 2 and find_inventory_item(spell.id) then
                             --0x36 packet
+                            spell.action_type = 'Trade'
                             if spell.target.distance <= 6 then
                                 command_registry[ts].proposed_packet = assemble_menu_item_packet(spell.target.id,spell.target.index,spell.id)
                             else
@@ -156,6 +158,10 @@ windower.register_event('outgoing text',function(original,modified,blocked,ffxi,
                         return true
                     end
                 else
+                    if spell.prefix == '/item' and bit.band(spell.target.spawn_type, 2) == 2 and find_inventory_item(spell.id) then
+                        --0x36 packet
+                        spell.action_type = 'Trade'
+                    end
                     return equip_sets('pretarget',-1,spell)
                 end
 			else

--- a/addons/GearSwap/triggers.lua
+++ b/addons/GearSwap/triggers.lua
@@ -67,22 +67,22 @@ windower.register_event('outgoing text',function(original,modified,blocked,ffxi,
             abil = res.job_abilities[pet_abilities[tonumber(splitline[2])]].name:gsub(string.char(7),' '):lower() -- .name, or .english?
         end
     end
-    
+
     if validabils[language][unified_prefix] and validabils[language][unified_prefix][abil] then
         temptarg, temp_mob_arr = valid_target(splitline[3])
     elseif validabils[language][unified_prefix] then
         temptarg, temp_mob_arr = valid_target(splitline[2])
     end
-    
+
     if unified_prefix and temptarg and (validabils[language][unified_prefix][abil] or unified_prefix=='/ra') then
         if st_flag then
             st_flag = nil
             return modified
         elseif temp_mob_arr then
             refresh_globals()
-            
+
             local r_line, find_monster_skill
-            
+
             function find_monster_skill(abil)
                 local line = false
                 if player.species and player.species.tp_moves then
@@ -96,7 +96,7 @@ windower.register_event('outgoing text',function(original,modified,blocked,ffxi,
                 end
                 return line
             end
-            
+
             if unified_prefix == '/ma' then
                 r_line = copy_entry(res.spells[validabils[language][unified_prefix][abil]])
                 storedcommand = command..' "'..windower.to_shift_jis(r_line[language])..'" '
@@ -120,20 +120,19 @@ windower.register_event('outgoing text',function(original,modified,blocked,ffxi,
                 storedcommand = command..' "'..windower.to_shift_jis(r_line[language])..'" '
             elseif unified_prefix == '/ra' then
                 r_line = copy_entry(resources_ranged_attack)
-                r_line.range = '25' -- temp
                 storedcommand = command..' '
             end
-            
+
             r_line.name = r_line[language]
             local spell = spell_complete(r_line)
             spell.target = temp_mob_arr
             spell.action_type = action_type_map[command]
-            
+
             if filter_pretarget(spell) then
                 if tonumber(splitline[splitline.n]) then
                     -- If the target is a number
                     local ts = command_registry:new_entry(spell)
-                    
+
                     if spell.prefix == '/item' then
                         -- Item use packet handling here
                         if bit.band(spell.target.spawn_type, 2) == 2 and find_inventory_item(spell.id) then


### PR DESCRIPTION
- Using an item on an NPC initiates a trade packet, while using an item on a player initiates an item use packet. This commit makes gearswap better aware of the difference.

- Also adds a field `range` with value of `25` to Ranged Attacks that previously would not have a `range` field in the associated `spell` table. (old change that I forgot to commit sooner)