### PR TITLE
Upgrade MountRoulette to 3.2.1

### DIFF
--- a/addons/MountRoulette/MountRoulette.lua
+++ b/addons/MountRoulette/MountRoulette.lua
@@ -28,7 +28,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 _addon.name = 'Mount Roulette'
 _addon.author = 'Dean James (Xurion of Bismarck)'
-_addon.version = '3.1.0'
+_addon.version = '3.2.1'
 _addon.commands = {'mountroulette', 'mr'}
 
 require('lists')
@@ -48,25 +48,11 @@ for _, mount in pairs(resources.mounts) do
 end
 
 function update_allowed_mounts()
-    local allowed_mounts_set = S{}
-    local kis = windower.ffxi.get_key_items()
+    local obtained_mounts_set = S(windower.ffxi.get_abilities().mounts):map(function (id)
+        return resources.mounts[id].name:lower()
+    end)
 
-    for _, id in ipairs(kis) do
-        local ki = resources.key_items[id]
-        if ki.category == 'Mounts' and ki.name ~= "trainer's whistle" then -- Don't care about the quest KI
-            local mount_index = possible_mounts:find(function(possible_mount)
-                return windower.wc_match(ki.name:lower(), '♪' .. possible_mount .. '*')
-            end)
-            local mount = possible_mounts[mount_index]
-
-            -- Add this to allowed mounts if it is not blacklisted
-            if not settings.blacklist:contains(mount) then
-                allowed_mounts_set:add(mount)
-            end
-        end
-    end
-
-    allowed_mounts = L(allowed_mounts_set)
+    allowed_mounts = L(obtained_mounts_set - settings.blacklist)
 end
 
 update_allowed_mounts()


### PR DESCRIPTION
Takes advantage of the new mounts information from Windower and removes the need to iterate over key item data.

https://github.com/xurion/ffxi-mount-roulette/issues/11