### PR TITLE
[DressUp] Update self model on job change regardless of Combat blinking setting

### DIFF
--- a/addons/DressUp/DressUp.lua
+++ b/addons/DressUp/DressUp.lua
@@ -85,11 +85,13 @@ windower.register_event('logout', function()
 end)
 
 windower.register_event('job change',function(job)
-    local isProfileLoaded = load_profile(res.jobs[job].name)
-    update_model(info.self.index)
-    if isProfileLoaded then
-        notice('Loaded profile: ' .. res.jobs[job].name)
-    end
+  local isProfileLoaded = load_profile(res.jobs[job].name)
+  if (not settings.blinking['self']['always'] and not settings.blinking['all']['always']) or isProfileLoaded then
+      update_model(info.self.index)
+  end
+  if isProfileLoaded then
+      notice('Loaded profile: ' .. res.jobs[job].name)
+  end
 end)
 
 

--- a/addons/DressUp/DressUp.lua
+++ b/addons/DressUp/DressUp.lua
@@ -85,8 +85,9 @@ windower.register_event('logout', function()
 end)
 
 windower.register_event('job change',function(job)
-    if load_profile(res.jobs[job].name) then
-        update_model(info.self.index)
+    local isProfileLoaded = load_profile(res.jobs[job].name)
+    update_model(info.self.index)
+    if isProfileLoaded then
         notice('Loaded profile: ' .. res.jobs[job].name)
     end
 end)

--- a/addons/DressUp/DressUp.lua
+++ b/addons/DressUp/DressUp.lua
@@ -85,13 +85,13 @@ windower.register_event('logout', function()
 end)
 
 windower.register_event('job change',function(job)
-  local isProfileLoaded = load_profile(res.jobs[job].name)
-  if (not settings.blinking['self']['always'] and not settings.blinking['all']['always']) or isProfileLoaded then
-      update_model(info.self.index)
-  end
-  if isProfileLoaded then
-      notice('Loaded profile: ' .. res.jobs[job].name)
-  end
+    local isProfileLoaded = load_profile(res.jobs[job].name)
+    if (not settings.blinking['self']['always'] and not settings.blinking['all']['always']) or isProfileLoaded then
+        update_model(info.self.index)
+    end
+    if isProfileLoaded then
+        notice('Loaded profile: ' .. res.jobs[job].name)
+    end
 end)
 
 


### PR DESCRIPTION
In some situations, you can end up with your gear locked to a previous job's lockstyle even after changing jobs.

A specific example is when you have DressUp settings set to lock in Combat but not Always, during Odyssey after doing a fight and getting sent back to the lobby, the game client sometimes thinks you're still in combat even though you're in the lobby. In this case, changing gear while not having a job or character profile set up in DressUp's settings (instead preferring in-game lockstyle) your character will be stuck looking like the previous job.

I modified the if statement on the job change event to always update the model even if there's no profile to load for the new job. It still attempts to load a profile.

![image](https://github.com/user-attachments/assets/62c336a3-08af-4a26-a7dc-d3d7e5ac3065)
