### PR TITLE
[gearswap] Fix player.target.type being not set sometimes.

### DIFF
--- a/addons/GearSwap/targets.lua
+++ b/addons/GearSwap/targets.lua
@@ -33,18 +33,14 @@ function valid_target(targ)
 
     if targ and pass_through_targs[targ] then
         local j = windower.ffxi.get_mob_by_target(targ)
-        if j then
-            spelltarget = target_complete(j)
-        end
+        spelltarget = target_complete(j)
         spelltarget.raw = targ
         return targ, spelltarget
     elseif targ then
         local id = tonumber(targ)
         if id then
             local j = windower.ffxi.get_mob_by_id(id)
-            if j then
-                spelltarget = target_complete(j)
-            end
+            spelltarget = target_complete(j)
             spelltarget.raw = targ
             return targ, spelltarget
         elseif targ ~= '' then


### PR DESCRIPTION
Let target_complete() deal with being passed `nil` tables directly, so it can properly set the `player.target.type` field when the specified target does not return any mob.