### PR TITLE
Fix argument parsing error for //gt days <arg2>

### DIFF
--- a/addons/gametime/gametime.lua
+++ b/addons/gametime/gametime.lua
@@ -452,6 +452,7 @@ windower.register_event('addon command', function (...)
             log('Showing time display.')
         end
     elseif args[1] == 'days' then
+        local asnum = tonumber(args[2])
         if args[2] == 'alpha' then
             inalpha = tostring(args[3]):zfill(3)
             inalpha = inalpha+0
@@ -459,9 +460,9 @@ windower.register_event('addon command', function (...)
                 gt.gtd:alpha(inalpha)
                 log('Day transparency set to '..inalpha..' ('..math.round(100-(inalpha/2.55),0)..'%).')
             end
-        elseif tonumber(args[2]) ~= nil and tonumber(args[2]) > 0 and tonumber(args[2]) < 9 then
-            gt.numdays = tonumber(args[2])
-            settings.numdays = tonumber(args[2])
+        elseif asnum and asnum > 0 and asnum < 9 then
+            gt.numdays = asnum
+            settings.numdays = asnum
             day_change(windower.ffxi.get_info().day)
         elseif args[2] == 'x' or args[2] == 'posx' then
             windower.send_command('gt daysx '..args[3])

--- a/addons/gametime/gametime.lua
+++ b/addons/gametime/gametime.lua
@@ -459,7 +459,7 @@ windower.register_event('addon command', function (...)
                 gt.gtd:alpha(inalpha)
                 log('Day transparency set to '..inalpha..' ('..math.round(100-(inalpha/2.55),0)..'%).')
             end
-        elseif tonumber(args[2]) > 0 and tonumber(args[2]) < 9 then
+        elseif tonumber(args[2]) ~= nil and tonumber(args[2]) > 0 and tonumber(args[2]) < 9 then
             gt.numdays = tonumber(args[2])
             settings.numdays = tonumber(args[2])
             day_change(windower.ffxi.get_info().day)

--- a/addons/gametime/gametime.lua
+++ b/addons/gametime/gametime.lua
@@ -452,7 +452,6 @@ windower.register_event('addon command', function (...)
             log('Showing time display.')
         end
     elseif args[1] == 'days' then
-        local asnum = tonumber(args[2])
         if args[2] == 'alpha' then
             inalpha = tostring(args[3]):zfill(3)
             inalpha = inalpha+0
@@ -460,22 +459,27 @@ windower.register_event('addon command', function (...)
                 gt.gtd:alpha(inalpha)
                 log('Day transparency set to '..inalpha..' ('..math.round(100-(inalpha/2.55),0)..'%).')
             end
-        elseif asnum and asnum > 0 and asnum < 9 then
-            gt.numdays = asnum
-            settings.numdays = asnum
-            day_change(windower.ffxi.get_info().day)
         elseif args[2] == 'x' or args[2] == 'posx' then
             windower.send_command('gt daysx '..args[3])
         elseif args[2] == 'y' or args[2] == 'posy' then
             windower.send_command('gt daysy '..args[3])
+        elseif args[2] == 'show' then
+            gt.gtd:show()
+            log('Showing day display.')
         elseif args[2] == 'hide' then
             gt.gtd:hide()
             log('Day display hidden.')
         elseif args[2] == 'reset' then
             gt.gtd:pos(0,0)
         else
-            gt.gtd:show()
-            log('Showing day display.')
+            local asnum = tonumber(args[2])
+            if not asnum or asnum < 1 or asnum > 8 then
+                log('Invalid command for //gt days')
+            else
+                gt.numdays = asnum
+                settings.numdays = asnum
+                day_change(windower.ffxi.get_info().day)
+            end
         end
     elseif args[1] == 'axis' then
         if args[2] == 'vertical' then

--- a/addons/gametime/gametime.lua
+++ b/addons/gametime/gametime.lua
@@ -463,9 +463,6 @@ windower.register_event('addon command', function (...)
             windower.send_command('gt daysx '..args[3])
         elseif args[2] == 'y' or args[2] == 'posy' then
             windower.send_command('gt daysy '..args[3])
-        elseif args[2] == 'show' then
-            gt.gtd:show()
-            log('Showing day display.')
         elseif args[2] == 'hide' then
             gt.gtd:hide()
             log('Day display hidden.')
@@ -474,7 +471,8 @@ windower.register_event('addon command', function (...)
         else
             local asnum = tonumber(args[2])
             if not asnum or asnum < 1 or asnum > 8 then
-                log('Invalid command for //gt days')
+                gt.gtd:show()
+                log('Showing day display.')
             else
                 gt.numdays = asnum
                 settings.numdays = asnum


### PR DESCRIPTION
As described on Discord:

Argument parsing bug in the `gametime` addon:
Line 462: `        elseif tonumber(args[2]) > 0 and tonumber(args[2]) < 9 then`
This causes any argument parsed after this line to fail because this line assumes the argument can be converted via `tonumber`. If the argument is a string (e.g., `hide`), the script will fail at this `if` statement because `tonumber` will convert the string to `nil` and then `nil` is an invalid comparison.

My fix:
`        elseif tonumber(args[2]) ~= nil and tonumber(args[2]) > 0 and tonumber(args[2]) < 9 then`