### PR TITLE
[GearSwap] Remove unneeded valid_target return value

### DIFF
--- a/addons/GearSwap/targets.lua
+++ b/addons/GearSwap/targets.lua
@@ -29,20 +29,19 @@
 
 function valid_target(targ)
     local spelltarget = {}
-    local spell_targ
 
     if targ and pass_through_targs[targ] then
         local j = windower.ffxi.get_mob_by_target(targ)
         spelltarget = target_complete(j)
         spelltarget.raw = targ
-        return targ, spelltarget
+        return spelltarget
     elseif targ then
         local id = tonumber(targ)
         if id then
             local j = windower.ffxi.get_mob_by_id(id)
             spelltarget = target_complete(j)
             spelltarget.raw = targ
-            return targ, spelltarget
+            return spelltarget
         elseif targ ~= '' then
             local targ_name = targ:lower()
             local mob_array = windower.ffxi.get_mob_array()
@@ -50,12 +49,12 @@ function valid_target(targ)
                 if v.name:lower()==targ_name and (not v.is_npc or v.spawn_type == 14) then
                     spelltarget = target_complete(v)
                     spelltarget.raw = targ
-                    return targ, spelltarget
+                    return spelltarget
                 end
             end
         end
     end
-    return false, false
+    return false
 end
 
 function target_complete(mob_table)

--- a/addons/GearSwap/triggers.lua
+++ b/addons/GearSwap/triggers.lua
@@ -53,7 +53,7 @@ windower.register_event('outgoing text',function(original,modified,blocked,ffxi,
     local command = splitline[1]
     local bstpet = (command == '/bstpet' and tonumber(splitline[2]))
     local unified_prefix = unify_prefix[command]
-    local abil, temptarg, temp_mob_arr
+    local abil, temp_mob_arr
     if splitline[2] and not bstpet then
         abil = splitline[2]:gsub(string.char(7),' '):lower() -- Why am I removing \x7?
     elseif splitline[2] and bstpet then
@@ -69,102 +69,101 @@ windower.register_event('outgoing text',function(original,modified,blocked,ffxi,
     end
 
     if validabils[language][unified_prefix] and validabils[language][unified_prefix][abil] then
-        temptarg, temp_mob_arr = valid_target(splitline[3])
+        temp_mob_arr = valid_target(splitline[3])
     elseif validabils[language][unified_prefix] then
-        temptarg, temp_mob_arr = valid_target(splitline[2])
+        temp_mob_arr = valid_target(splitline[2])
     end
 
-    if unified_prefix and temptarg and (validabils[language][unified_prefix][abil] or unified_prefix=='/ra') then
+    if unified_prefix and temp_mob_arr and (validabils[language][unified_prefix][abil] or unified_prefix=='/ra') then
         if st_flag then
             st_flag = nil
             return modified
-        elseif temp_mob_arr then
-            refresh_globals()
+        end
+        refresh_globals()
 
-            local r_line, find_monster_skill
+        local r_line, find_monster_skill
 
-            function find_monster_skill(abil)
-                local line = false
-                if player.species and player.species.tp_moves then
-                    -- Iterates over currently available monster TP moves instead of using validabils
-                    for i,v in pairs(player.species.tp_moves) do
-                        if res.monster_skills[i][language]:lower() == abil then
-                            line = copy_entry(res.monster_skills[i])
-                            break
-                        end
+        function find_monster_skill(abil)
+            local line = false
+            if player.species and player.species.tp_moves then
+                -- Iterates over currently available monster TP moves instead of using validabils
+                for i,v in pairs(player.species.tp_moves) do
+                    if res.monster_skills[i][language]:lower() == abil then
+                        line = copy_entry(res.monster_skills[i])
+                        break
                     end
                 end
-                return line
             end
+            return line
+        end
 
-            if unified_prefix == '/ma' then
-                r_line = copy_entry(res.spells[validabils[language][unified_prefix][abil]])
+        if unified_prefix == '/ma' then
+            r_line = copy_entry(res.spells[validabils[language][unified_prefix][abil]])
+            storedcommand = command..' "'..windower.to_shift_jis(r_line[language])..'" '
+        elseif unified_prefix == '/ms' and find_monster_skill(abil) then
+            r_line = find_monster_skill(abil)
+            storedcommand = command..' "'..windower.to_shift_jis(r_line[language])..'" '
+        elseif unified_prefix == '/ws' then
+            r_line = copy_entry(res.weapon_skills[validabils[language][unified_prefix][abil]])
+            storedcommand = command..' "'..windower.to_shift_jis(r_line[language])..'" '
+        elseif unified_prefix == '/ja' then
+            r_line = copy_entry(res.job_abilities[validabils[language][unified_prefix][abil]])
+            if bstpet then
+                storedcommand = command..' '..splitline[2]
+            else
                 storedcommand = command..' "'..windower.to_shift_jis(r_line[language])..'" '
-            elseif unified_prefix == '/ms' and find_monster_skill(abil) then
-                r_line = find_monster_skill(abil)
-                storedcommand = command..' "'..windower.to_shift_jis(r_line[language])..'" '
-            elseif unified_prefix == '/ws' then
-                r_line = copy_entry(res.weapon_skills[validabils[language][unified_prefix][abil]])
-                storedcommand = command..' "'..windower.to_shift_jis(r_line[language])..'" '
-            elseif unified_prefix == '/ja' then
-                r_line = copy_entry(res.job_abilities[validabils[language][unified_prefix][abil]])
-                if bstpet then
-                    storedcommand = command..' '..splitline[2]
-                else
-                    storedcommand = command..' "'..windower.to_shift_jis(r_line[language])..'" '
-                end
-            elseif unified_prefix == '/item' then
-                r_line = copy_entry(res.items[validabils[language][unified_prefix][abil]])
-                r_line.prefix = '/item'
-                r_line.type = 'Item'
-                storedcommand = command..' "'..windower.to_shift_jis(r_line[language])..'" '
-            elseif unified_prefix == '/ra' then
-                r_line = copy_entry(resources_ranged_attack)
-                storedcommand = command..' '
             end
+        elseif unified_prefix == '/item' then
+            r_line = copy_entry(res.items[validabils[language][unified_prefix][abil]])
+            r_line.prefix = '/item'
+            r_line.type = 'Item'
+            storedcommand = command..' "'..windower.to_shift_jis(r_line[language])..'" '
+        elseif unified_prefix == '/ra' then
+            r_line = copy_entry(resources_ranged_attack)
+            storedcommand = command..' '
+        end
 
-            r_line.name = r_line[language]
-            local spell = spell_complete(r_line)
-            spell.target = temp_mob_arr
-            spell.action_type = action_type_map[command]
+        r_line.name = r_line[language]
+        local spell = spell_complete(r_line)
+        spell.target = temp_mob_arr
+        spell.action_type = action_type_map[command]
 
-            if spell.prefix == '/item' and spell.target.type ~= 'NONE' and bit.band(spell.target.spawn_type, 2) == 2 then
-                spell.action_type = 'Trade'
-            end
+        if spell.prefix == '/item' and spell.target.type ~= 'NONE' and bit.band(spell.target.spawn_type, 2) == 2 then
+            spell.action_type = 'Trade'
+        end
 
-            if filter_pretarget(spell) then
-                if tonumber(splitline[splitline.n]) then
-                    -- If the target is a number
-                    local ts = command_registry:new_entry(spell)
+        if filter_pretarget(spell) then
+            if tonumber(splitline[splitline.n]) then
+                -- If the target is a number
+                local ts = command_registry:new_entry(spell)
 
-                    if spell.prefix == '/item' then
-                        -- Item use packet handling here
-                        if spell.action_type == 'Trade' and find_inventory_item(spell.id) then
-                            --0x36 packet
-                            if spell.target.distance <= 6 then
-                                command_registry[ts].proposed_packet = assemble_menu_item_packet(spell.target.id,spell.target.index,spell.id)
-                            else
-                                 windower.add_to_chat(67, "Target out of range.")
-                                 return true
-                            end
-                        elseif find_usable_item(spell.id) then
-                            --0x37 packet
-                            command_registry[ts].proposed_packet = assemble_use_item_packet(spell.target.id,spell.target.index,spell.id)
+                if spell.prefix == '/item' then
+                    -- Item use packet handling here
+                    if spell.action_type == 'Trade' and find_inventory_item(spell.id) then
+                        --0x36 packet
+                        if spell.target.distance <= 6 then
+                            command_registry[ts].proposed_packet = assemble_menu_item_packet(spell.target.id,spell.target.index,spell.id)
+                        else
+                             windower.add_to_chat(67, "Target out of range.")
+                             return true
                         end
-                    else
-                        command_registry[ts].proposed_packet = assemble_action_packet(spell.target.id,spell.target.index,outgoing_action_category_table[unify_prefix[spell.prefix]],spell.id,initialize_arrow_offset(spell.target))
-                    end
-                    -- The packets created above should not be used.
-                    if command_registry[ts].proposed_packet then
-                        equip_sets('precast',ts,spell)
-                        return true
+                    elseif find_usable_item(spell.id) then
+                        --0x37 packet
+                        command_registry[ts].proposed_packet = assemble_use_item_packet(spell.target.id,spell.target.index,spell.id)
                     end
                 else
-                    return equip_sets('pretarget',-1,spell)
+                    command_registry[ts].proposed_packet = assemble_action_packet(spell.target.id,spell.target.index,outgoing_action_category_table[unify_prefix[spell.prefix]],spell.id,initialize_arrow_offset(spell.target))
                 end
-			else
-                return equip_sets('filtered_action',-1,spell)
-			end
+                -- The packets created above should not be used.
+                if command_registry[ts].proposed_packet then
+                    equip_sets('precast',ts,spell)
+                    return true
+                end
+            else
+                return equip_sets('pretarget',-1,spell)
+            end
+        else
+            return equip_sets('filtered_action',-1,spell)
         end
     end
     return modified

--- a/addons/GearSwap/user_functions.lua
+++ b/addons/GearSwap/user_functions.lua
@@ -97,7 +97,7 @@ function change_target(name)
     end
     if name and type(name)=='string' then
         if valid_target(name) then
-            _,_global.new_target = valid_target(name)
+            _global.new_target = valid_target(name)
         else
             error('\nGearSwap: change_target() was passed an invalid value ('..tostring(name)..'). (must be a valid target)', 2)
         end


### PR DESCRIPTION
Only outgoing text uses valid_target's first return value so this commit will adopt outgoing text's perspective.

temptarg serves no useful purpose. Whenever it is false, temp_mob_arr is also false. Whenever it is not nil, temp_mob_arr is also not nil. So when checking for valid_target's success or failure, temp_mob_arr can be used interchangeably with temptarg. Moreover, temptarg is also stored inside of temp_mob_arr as temp_mob_arr.raw so with temptarg removed we still have access to its value. Removing temptarg enables outgoing text to save on one indent.

Also remove unused spell_targ local variable from valid_target while here.