### PR TITLE
[resources.lua] Throw a helpful error when requested resource file is missing

### DIFF
--- a/addons/libs/resources.lua
+++ b/addons/libs/resources.lua
@@ -26,10 +26,9 @@ local resource_mt = {}
 
 -- The metatable for the root resource table
 local resources = setmetatable({}, {__index = function(t, k)
-    if fns[k] then
-        t[k] = setmetatable(fns[k](), resource_mt)
-        return t[k]
-    end
+    local fn = assert(k and fns[k], 'Unable to load resource "%s". Resource file not found!\n  Resolution: To attempt a force update of resources (and addons and libs), delete directory\n  "%s" and restart Windower.':format(tostring(k), (windower.windower_path..'updates'):gsub('\\','\\\\')))
+    t[k] = setmetatable(fn(), resource_mt)
+    return t[k]
 end})
 
 _libs.resources = resources


### PR DESCRIPTION
<img width="1512" height="116" alt="image" src="https://github.com/user-attachments/assets/9a650c86-7558-4422-8cde-a69fbc5d0739" />