### PR TITLE
[GearSwap] Remove unnecessary command registry spell assignment

### DIFF
--- a/addons/GearSwap/flow.lua
+++ b/addons/GearSwap/flow.lua
@@ -219,7 +219,6 @@ function equip_sets_exit(swap_type,ts,val1)
             end
 
             -- Compose a proposed packet for the given action (this should be possible after pretarget)
-            command_registry[ts].spell = val1
             if val1.target and val1.target.id and val1.target.index and val1.prefix and unify_prefix[val1.prefix] then
                 if val1.prefix == '/item' then
                     -- Item use packet handling here


### PR DESCRIPTION
For each action which triggers GearSwap, there is only ever one spell table in memory for that action (from trigger -> midcast). cmd_reg:new_entry already assigns a reference to that spell table when the command registry entry is created, so there is no need to assign the same reference again.

Small note: a new, duplicate spell table is created post-midcast in response to receiving an incoming action packet, so if that action packet was received as a result of a GearSwap fired action then technically there are now two spell tables in memory for the same action. But:
1. We don't care that much because the critical task of firing the action correctly was already completed successfully.
2. If we really wanted to we could reuse the original spell table and avoid creating a second one, only allocating memory for a new spell table if the original spell table could not be retrieved.