### PR TITLE
[GearSwap] Remove unneeded pretarget checks

### DIFF
--- a/addons/GearSwap/flow.lua
+++ b/addons/GearSwap/flow.lua
@@ -219,7 +219,7 @@ function equip_sets_exit(swap_type,ts,val1)
             end
 
             -- Compose a proposed packet for the given action (this should be possible after pretarget)
-            if val1.target and val1.target.id and val1.target.index and val1.prefix and unify_prefix[val1.prefix] then
+            if val1.target.id and val1.target.index then
                 if val1.prefix == '/item' then
                     -- Item use packet handling here
                     if bit.band(val1.target.spawn_type, 2) == 2 and find_inventory_item(val1.id) then
@@ -252,7 +252,7 @@ function equip_sets_exit(swap_type,ts,val1)
                 end
             end
 
-            if ts and command_registry[ts] and val1.target then
+            if ts and command_registry[ts] then
                 if st_targs[val1.target.raw] then
                 -- st targets
                     st_flag = true


### PR DESCRIPTION
val1.target, val1.prefix, and unify_prefix[val1.prefix] do not need to be checked for the following reasons:

val1.target - Intended to contain the mob table, this is only ever assigned by valid_target, either from within outgoing text or from within change_target. valid_target can only return one of two things, either it returns false, or it returns a valid table. Both outgoing text and change_target check to make sure false was not returned; in outgoing text's case it will return early, and in change_target's case it will not make any assignment so val1.target will retain its original value from outgoing text's valid_target call. Therefore it is impossible for val1.target to be anything other than a valid table when inside equip_sets/equip_sets_exit in the pretarget event during standard GearSwap flow.

Caveat: The user file could decide to just write to the spell table directly and assign nil to the target. Suppose this was a genuine use case where the user pretarget function intended on trying to work out a new target to change the spell to, but by accident the target they obtained turned out to be nil and they failed to check it and went ahead with the target change.

With the current GearSwap code, if they did the proper thing and used the change_target function, they would get an error telling them their proposed target was invalid. If they did the insane thing and just wrote to the spell table directly, GearSwap would silently fail and release the command to outgoing text, so their action would still be performed and it might appear like things are working, but in reality GearSwap is not working and they are not getting any precast or midcast gear swaps.

With this commit's removal of the val1.target checks, if they did the proper thing and used change_target they would get the same error result as before, but if they did the insane spell table write they would now also get an error telling them that target was nil. So you could say this commit actually improves things by steering insane user files towards the proper behavior of hitting an error telling them their target was invalid.

val1.prefix - This value is obtained from the action's resource table, or in the case of items, outgoing text will add it so the item spell table can stay consistent with that of other actions. The only way this check could fail is if the resources broke, in which case GearSwap is doomed, having an extra prefix check will not save it.

unify_prefix[val1.prefix] - Similar story as above, but the resource breakage would not need to be as severe in order for this check to fail, i.e. a game update happened which changed action prefixes, and the resources were correctly updated to reflect this so they are not actually broken, but GearSwap's unify_prefix table was not yet updated. The end result is still the same though, GearSwap is doomed and keeping this check around will not save it.