### PR TITLE
[GearSwap] Move st pronoun check to appropriate place and fix small bug

### DIFF
--- a/addons/GearSwap/flow.lua
+++ b/addons/GearSwap/flow.lua
@@ -187,7 +187,7 @@ end
 
 
 -----------------------------------------------------------------------------------
---Name: equip_sets_exit(swap_type,ind,val1)
+--Name: equip_sets_exit(swap_type, ts, val1)
 --Desc: Cleans up the global table and leaves equip_sets properly.
 --Args:
 ---- swap_type - Current swap type for equip_sets
@@ -197,15 +197,15 @@ end
 --Returns:
 ---- none
 -----------------------------------------------------------------------------------
-function equip_sets_exit(swap_type,ts,val1)
+function equip_sets_exit(swap_type, ts, val1)
     if command_registry[ts] then
-        table.update(command_registry[ts],_global)
+        table.update(command_registry[ts], _global)
     end
     if type(swap_type) == 'string' then
         if swap_type == 'pretarget' then
 
             if command_registry[ts].cancel_spell then
-                msg.debugging("Action canceled ("..storedcommand..' '..val1.target.raw..")")
+                msg.debugging('Action canceled (' .. storedcommand .. ' ' .. val1.target.raw .. ')')
                 storedcommand = nil
                 command_registry:delete_entry(ts)
                 return true
@@ -218,6 +218,11 @@ function equip_sets_exit(swap_type,ts,val1)
                 val1.target = command_registry[ts].new_target -- Switch target, if it is requested.
             end
 
+            if st_targs[val1.target.raw] then
+                st_flag = true
+                return storedcommand .. ' ' .. val1.target.raw
+            end
+
             -- Compose a proposed packet for the given action (this should be possible after pretarget)
             if val1.target.id and val1.target.index then
                 if val1.prefix == '/item' then
@@ -225,51 +230,48 @@ function equip_sets_exit(swap_type,ts,val1)
                     if bit.band(val1.target.spawn_type, 2) == 2 and find_inventory_item(val1.id) then
                         -- 0x36 packet
                         if val1.target.distance <= 6 then
-                            command_registry[ts].proposed_packet = assemble_menu_item_packet(val1.target.id,val1.target.index,val1.id)
+                            command_registry[ts].proposed_packet = assemble_menu_item_packet(val1.target.id, val1.target.index, val1.id)
                         else
-                            windower.add_to_chat(67, "Target out of range.")
+                            windower.add_to_chat(67, 'Target out of range.')
                         end
                     elseif find_usable_item(val1.id) then
                         -- 0x37 packet
-                        command_registry[ts].proposed_packet = assemble_use_item_packet(val1.target.id,val1.target.index,val1.id)
+                        command_registry[ts].proposed_packet = assemble_use_item_packet(val1.target.id, val1.target.index, val1.id)
                     end
                     if not command_registry[ts].proposed_packet then
                         command_registry:delete_entry(ts)
                     end
                 elseif outgoing_action_category_table[unify_prefix[val1.prefix]] then
                     if filter_precast(val1) then
-                        command_registry[ts].proposed_packet = assemble_action_packet(val1.target.id,val1.target.index,outgoing_action_category_table[unify_prefix[val1.prefix]],val1.id,command_registry[ts].target_arrow)
+                        command_registry[ts].proposed_packet = assemble_action_packet(val1.target.id, val1.target.index, outgoing_action_category_table[unify_prefix[val1.prefix]], val1.id, command_registry[ts].target_arrow)
                         if not command_registry[ts].proposed_packet then
                             command_registry:delete_entry(ts)
 
-                            msg.debugging("Unable to create a packet for this command because the target is still invalid after pretarget ("..storedcommand..' '..val1.target.raw..")")
+                            msg.debugging('Unable to create a packet for this command because the target is still invalid after pretarget (' .. storedcommand .. ' ' .. val1.target.raw .. ')')
                             storedcommand = nil
-                            return storedcommand..' '..val1.target.raw
+                            return storedcommand .. ' ' .. val1.target.raw
                         end
                     end
                 else
-                    msg.debugging("Hark, what weird prefix through yonder window breaks? "..tostring(val1.prefix))
+                    msg.debugging('Hark, what weird prefix through yonder window breaks? ' .. tostring(val1.prefix))
                 end
             end
 
             if ts and command_registry[ts] then
-                if st_targs[val1.target.raw] then
-                -- st targets
-                    st_flag = true
-                elseif not val1.target.name then
+                if not val1.target.name then
                 -- Spells with invalid pass_through_targs, like using <t> without a target
                     command_registry:delete_entry(ts)
-                    msg.debugging("Change target was used to pick an invalid target ("..storedcommand..' '..val1.target.raw..")")
-                    local ret = storedcommand..' '..val1.target.raw
+                    msg.debugging('Change target was used to pick an invalid target (' .. storedcommand .. ' ' .. val1.target.raw .. ')')
+                    local ret = storedcommand .. ' ' .. val1.target.raw
                     storedcommand = nil
                     return ret
                 else
                 -- Spells with complete target information
                 -- command_registry[ts] is deleted for cancelled spells
                     if command_registry[ts].pretarget_cast_delay == 0 then
-                        equip_sets('precast',ts,val1)
+                        equip_sets('precast', ts, val1)
                     else
-                        windower.send_command('@wait '..command_registry[ts].pretarget_cast_delay..';lua i '.._addon.name..' pretarget_delayed_cast '..ts)
+                        windower.send_command('@wait ' .. command_registry[ts].pretarget_cast_delay .. ';lua i ' .. _addon.name .. ' pretarget_delayed_cast ' .. ts)
                     end
                     return true
                 end
@@ -281,7 +283,7 @@ function equip_sets_exit(swap_type,ts,val1)
         elseif swap_type == 'precast' then
             -- Update the target_arrow
             if val1.prefix ~= '/item' then
-                command_registry[ts].proposed_packet = assemble_action_packet(val1.target.id,val1.target.index,outgoing_action_category_table[unify_prefix[val1.prefix]],val1.id,command_registry[ts].target_arrow)
+                command_registry[ts].proposed_packet = assemble_action_packet(val1.target.id, val1.target.index, outgoing_action_category_table[unify_prefix[val1.prefix]], val1.id, command_registry[ts].target_arrow)
             end
             return precast_send_check(ts)
         elseif swap_type == 'filtered_action' and command_registry[ts] and command_registry[ts].cancel_spell then
@@ -290,7 +292,7 @@ function equip_sets_exit(swap_type,ts,val1)
             return true
         elseif swap_type == 'midcast' and _settings.demo_mode then
             command_registry[ts].midaction = false
-            equip_sets('aftercast',ts,val1)
+            equip_sets('aftercast', ts, val1)
         elseif swap_type == 'aftercast' then
             if ts then
                 command_registry:delete_entry(ts)


### PR DESCRIPTION
We should check for an st pronoun at the earliest possible moment, i.e. immediately after a potential target change, since there can never be an action that gets fired for an st pronoun. By definition, an st pronoun will trigger a subtarget arrow for the user to select a target with, so there is no target until that selection is made and a new command is issued to outgoing text with the selected target. For this reason it makes sense to check for an st pronoun before doing any packet assembly, because those packets will never be used in case of an st pronoun. Furthermore, there is nothing else to do after setting st_flag except wait for the 'real' command with the real target to be received by outgoing text, so we should return immediately.

The previous st pronoun code path would return nil after setting st_flag, but this is not correct, since the original target could have been \<t\> but the user pretarget function decided to change this to \<st\>. In this case GearSwap must return the \<st\> pronoun to outgoing text in order to grant the user the subtarget arrow they requested. However at present since nil is returned, it is \<t\> that will get released to outgoing text instead of \<st\>, which will cause several problems:
1. The action will be initiated immediately with the current target, which could be both the unintended target and the unintended timing.
2. There will be no precast or midcast gear swaps for the action.
3. The st_flag is left set, which means the next valid command GearSwap receives will also not receive any gear swaps since outgoing text will return early after clearing the st_flag before initiating standard GearSwap flow.

Since this commit is a more innocent change, did all code style updates for equip_sets_exit in this commit.