### PR TITLE
[GearSwap] Only do item trade check once per code path

### DIFF
--- a/addons/GearSwap/flow.lua
+++ b/addons/GearSwap/flow.lua
@@ -228,6 +228,7 @@ function equip_sets_exit(swap_type, ts, val1)
                 if val1.prefix == '/item' then
                     -- Item use packet handling here
                     if bit.band(val1.target.spawn_type, 2) == 2 and find_inventory_item(val1.id) then
+                        val1.action_type = 'Trade'
                         -- 0x36 packet
                         if val1.target.distance <= 6 then
                             command_registry[ts].proposed_packet = assemble_menu_item_packet(val1.target.id, val1.target.index, val1.id)

--- a/addons/GearSwap/triggers.lua
+++ b/addons/GearSwap/triggers.lua
@@ -135,10 +135,6 @@ windower.register_event('outgoing text', function(original, modified)
     spell.target = temp_mob_arr
     spell.action_type = action_type_map[command]
 
-    if spell.prefix == '/item' and spell.target.type ~= 'NONE' and bit.band(spell.target.spawn_type, 2) == 2 then
-        spell.action_type = 'Trade'
-    end
-
     if not filter_pretarget(spell) then
         return equip_sets('filtered_action', -1, spell)
     end
@@ -152,8 +148,9 @@ windower.register_event('outgoing text', function(original, modified)
 
         if spell.prefix == '/item' then
             -- Item use packet handling here
-            if spell.action_type == 'Trade' and find_inventory_item(spell.id) then
-                --0x36 packet
+            if bit.band(spell.target.spawn_type, 2) == 2 and find_inventory_item(spell.id) then
+                -- 0x36 packet
+                spell.action_type = 'Trade'
                 if spell.target.distance <= 6 then
                     command_registry[ts].proposed_packet = assemble_menu_item_packet(spell.target.id, spell.target.index, spell.id)
                 else
@@ -161,7 +158,7 @@ windower.register_event('outgoing text', function(original, modified)
                      return true
                 end
             elseif find_usable_item(spell.id) then
-                --0x37 packet
+                -- 0x37 packet
                 command_registry[ts].proposed_packet = assemble_use_item_packet(spell.target.id, spell.target.index, spell.id)
             end
         else


### PR DESCRIPTION
At present for the pretarget code path, the bit.band spawn type check gets performed twice, once in outgoing text, and again in pretarget. We should only need to perform this check once. In addition, the determination if the current action type is a trade or not is only performed in outgoing text, before the userfile might change the target to something different in pretarget. If the target did get changed in pretarget to something with a different spawn type, the initial trade action type that was determined in outgoing text might no longer be correct. This would be the case if the initial target was an NPC, and the new target was non-NPC, or vice versa. So this commit determines the item action type for the pretarget code path only after the target may have been changed to ensure it is correct, and moves the outgoing text item action type check to inside the target ID code path to avoid it being performed twice for pretarget code path.