### PR TITLE
Fixing packet fields bugs

### DIFF
--- a/addons/libs/packets/fields.lua
+++ b/addons/libs/packets/fields.lua
@@ -3457,7 +3457,7 @@ fields.incoming[0x0B5] = L{
 }
 
 -- Reservation Response
-packets.raw_fields.incoming[0x0BF] = L{
+fields.incoming[0x0BF] = L{
     {ctype='unsigned short',    label='_unknown1'},                             -- 04
     {ctype='unsigned short',    label='Result'},                                -- 06   Success is 4, other values are failures
     {ctype='unsigned int',      label='_unknown2'},                             -- 08

--- a/addons/libs/packets/fields.lua
+++ b/addons/libs/packets/fields.lua
@@ -672,8 +672,9 @@ fields.outgoing[0x05B] = L{
     {ctype='unsigned int',      label='Target',             fn=id},             -- 04
     {ctype='unsigned int',      label='Option Index'},                          -- 08
     {ctype='unsigned short',    label='Target Index',       fn=index},          -- 0C
-    {ctype='bool',              label='Automated Message'},                     -- 0E   1 if continuing the current menu, 0 if ending
-    {ctype='unsigned char',     label='_padding'},                              -- 0F   Upper bits of a Mode short including the previous bool
+    {ctype='bool',              label='Continue',                               -- 0E   Determines which mode the menu uses
+                                alias='Automated Message'},
+    {ctype='unsigned char',     label='_padding'            const=0},           -- 0F
     {ctype='unsigned short',    label='Zone',               fn=zone},           -- 10
     {ctype='unsigned short',    label='Menu ID'},                               -- 12
 }
@@ -688,7 +689,7 @@ fields.outgoing[0x05C] = L{
     {ctype='unsigned short',    label='Zone'},                                  -- 18
     {ctype='unsigned short',    label='Menu ID'},                               -- 1A
     {ctype='unsigned short',    label='Target Index',       fn=index},          -- 1C
-    {ctype='unsigned char',     label='Mode',               const=1},           -- 1E
+    {ctype='bool',              label='Continue',           const=true},        -- 1E   Always set for warp requests
     {ctype='unsigned char',     label='Rotation'},                              -- 1F
 }
 
@@ -3436,7 +3437,7 @@ fields.incoming[0x0AC] = L{
 }
 
 fields.incoming[0x0AE] = L{
-    {ctype='data[7]',        label='Mounts'},                                   -- 04
+    {ctype='data[7]',           label='Mounts'},                                -- 04
 }
 
 -- Moblin Maze Mongers information

--- a/addons/libs/packets/fields.lua
+++ b/addons/libs/packets/fields.lua
@@ -670,11 +670,10 @@ fields.outgoing[0x05A] = L{
 -- Dialogue options
 fields.outgoing[0x05B] = L{
     {ctype='unsigned int',      label='Target',             fn=id},             -- 04
-    {ctype='unsigned short',    label='Option Index'},                          -- 08
-    {ctype='unsigned short',    label='_unknown1'},                             -- 0A
+    {ctype='unsigned int',      label='Option Index'},                          -- 08
     {ctype='unsigned short',    label='Target Index',       fn=index},          -- 0C
-    {ctype='bool',              label='Automated Message'},                     -- 0E   1 if the response packet is automatically generated, 0 if it was selected by you
-    {ctype='unsigned char',     label='_unknown2'},                             -- 0F
+    {ctype='bool',              label='Automated Message'},                     -- 0E   1 if continuing the current menu, 0 if ending
+    {ctype='unsigned char',     label='_padding'},                              -- 0F   Upper bits of a Mode short including the previous bool
     {ctype='unsigned short',    label='Zone',               fn=zone},           -- 10
     {ctype='unsigned short',    label='Menu ID'},                               -- 12
 }
@@ -685,11 +684,11 @@ fields.outgoing[0x05C] = L{
     {ctype='float',             label='Z'},                                     -- 08
     {ctype='float',             label='Y'},                                     -- 0C
     {ctype='unsigned int',      label='Target ID',          fn=id},             -- 10   NPC that you are requesting a warp from
-    {ctype='unsigned int',      label='_unknown1'},                             -- 14   01 00 00 00 observed
+    {ctype='unsigned int',      label='Option Index'},                          -- 14
     {ctype='unsigned short',    label='Zone'},                                  -- 18
     {ctype='unsigned short',    label='Menu ID'},                               -- 1A
     {ctype='unsigned short',    label='Target Index',       fn=index},          -- 1C
-    {ctype='unsigned char',     label='_unknown2',          const=1},           -- 1E
+    {ctype='unsigned char',     label='Mode',               const=1},           -- 1E
     {ctype='unsigned char',     label='Rotation'},                              -- 1F
 }
 
@@ -2030,7 +2029,7 @@ fields.incoming[0x033] = L{
     {ctype='char[16]',          label='_dupeNPC Name1'},                        -- 20
     {ctype='char[16]',          label='_dupeNPC Name2'},                        -- 30
     {ctype='char[16]',          label='_dupeNPC Name3'},                        -- 40
-    {ctype='char[32]',          label='Menu Parameters'},                       -- 50   The way this information is interpreted varies by menu.
+    {ctype='data[32]',          label='Menu Parameters'},                       -- 50   The way this information is interpreted varies by menu.
 }
 
 -- NPC Interaction Type 2
@@ -3437,7 +3436,7 @@ fields.incoming[0x0AC] = L{
 }
 
 fields.incoming[0x0AE] = L{
-    {ctype='data[7]',        label='Mounts'},                                -- 04
+    {ctype='data[7]',        label='Mounts'},                                   -- 04
 }
 
 -- Moblin Maze Mongers information
@@ -3455,6 +3454,14 @@ fields.incoming[0x0B5] = L{
     {ctype='data[0x14]',        label='_unknown1'},                             -- 04
     {ctype='unsigned int',      label='Number of Opens'},                       -- 18
     {ctype='unsigned int',      label='_unknown2'},                             -- 1C
+}
+
+-- Reservation Response
+packets.raw_fields.incoming[0x0BF] = L{
+    {ctype='unsigned short',    label='_unknown1'},                             -- 04
+    {ctype='unsigned short',    label='Result'},                                -- 06   Success is 4, other values are failures
+    {ctype='unsigned int',      label='_unknown2'},                             -- 08
+    {ctype='unsigned int',      label='NPC Index'},                             -- 0C
 }
 
 -- Alliance status update


### PR DESCRIPTION
Fixed the following packets fields:

Outgoing 0x05B
Corrected the option index from a short to an int
Updated the _unknown2 name and comment to reflect that it's actually upper bit padding for a short that includes the 'Automated Message' bool (all 16 bits will either be a 1 or 0 value, but technically could be any value). Discussion on discord suggested to keep this as is to not break addons, but really the bool and char should be combined into a single short called 'Mode' similar to below.

Outgoing 0x05C
Corrected the _unknown1 value to its actual usage, an option index mimicing the usage in 0x05B.
Updated the _unknown2 name to 'Mode' due to not being limited by previously called 'Automated Message' bool, but can change this to match the above bool+char if desired (though it would lock into this paradigm on both).

Incoming 0x033
Corrected the ctype of the menu parameters from char[32] to data[32] as the other packets use, which also fixes issues when there is a 0 value that would terminate processing of the string.

Incoming 0x0BF
Added missing packet data for instance reservations. Description already present in data.lua.