### PR TITLE
fix: GS - add "you already have that roll" to unable_to_use

### DIFF
--- a/addons/GearSwap/statics.lua
+++ b/addons/GearSwap/statics.lua
@@ -101,7 +101,7 @@ default_slot_map[0]= 'main'
 jas = {false,false,false,false,false,true,false,false,false,false,false,false,false,true,true,false}-- {6,14,15}
 readies = {false,false,false,false,false,false,true,true,true,false,false,true,false,false,false,false} -- {7,8,9,12}
 uses = {false,true,true,true,true,false,false,false,false,false,true,false,true,false,false,false}--{2,3,4,5,11,13}
-unable_to_use = T{17,18,55,56,87,88,89,90,104,191,308,313,325,410,428,561,574,579,580,581,661,665,
+unable_to_use = T{17,18,55,56,87,88,89,90,104,191,308,313,325,410,428,429,561,574,579,580,581,661,665,
     12,16,34,35,40,47,48,49,71,72,76,78,84,91,92,95,96,106,111,128,154,155,190,192,193,198,
     199,215,216,217,218,219,220,233,246,247,307,315,316,328,337,338,346,347,348,349,356,411,443,444,
     445,446,514,516,517,518,523,524,525,547,568,569,575,649,660,662,666,700,701,62,717} -- Probably don't need some of these (event action) 


### PR DESCRIPTION
I noticed that it doesn't swap back to aftercast gear if you use a roll that you already have up (message 429).