### PR TITLE
[Yush] Clear pressed keys when window loses focus

### DIFF
--- a/addons/Yush/Yush.lua
+++ b/addons/Yush/Yush.lua
@@ -339,6 +339,10 @@ windower.register_event('keyboard', function(dik, down)
     end
 end)
 
+windower.register_event('lose focus', function()
+    keys:clear()
+end)
+
 windower.register_event('prerender', function()
     if settings.Verbose and settings.VerboseOutput == 'Text' then
         label:show()


### PR DESCRIPTION
On some operating systems (Windows 11 and Linux seem to be observed so far), the keyboard event may not fire on key unpress when the window has switched focus, i.e. alt+tab changes to a new window, but the old window running Windower does not see the alt and/or tab keys get released.

With the switch_focus addon being popular, and users making all kinds of key bindings for switch_focus commands to switch their windows, the problem may not be limited to just the alt and tab keys, so this commit clears all pressed keys that Yush was tracking when the window loses focus so they do not behave as being stuck down after becoming the active window again.