### PR TITLE
Remove all spaces from "Addon Name" field for all addons

### DIFF
--- a/addons/BattleStations/battlestations.lua
+++ b/addons/BattleStations/battlestations.lua
@@ -26,7 +26,7 @@ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ]]
 
-_addon.name     = 'Battle Stations'
+_addon.name     = 'BattleStations'
 _addon.description = 'Change or remove the default battle music.'
 _addon.author   = 'Sjshovan (Apogee) sjshovan@gmail.com'
 _addon.version  = '0.9.1'

--- a/addons/EmpyPopTracker/EmpyPopTracker.lua
+++ b/addons/EmpyPopTracker/EmpyPopTracker.lua
@@ -26,7 +26,7 @@ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ]]
 
-_addon.name = 'Empy Pop Tracker'
+_addon.name = 'EmpyPopTracker'
 _addon.author = 'Dean James (Xurion of Bismarck)'
 _addon.commands = { 'ept', 'empypoptracker' }
 _addon.version = '2.8.0'

--- a/addons/JobChange/jobchange.lua
+++ b/addons/JobChange/jobchange.lua
@@ -26,7 +26,7 @@ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ]]
 
-_addon.name = 'Job Change'
+_addon.name = 'JobChange'
 _addon.author = 'Sammeh; Akaden'
 _addon.version = '1.0.4'
 _addon.command = 'jc'

--- a/addons/MountMuzzle/mountmuzzle.lua
+++ b/addons/MountMuzzle/mountmuzzle.lua
@@ -26,7 +26,7 @@ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 --]]
 
-_addon.name = 'Mount Muzzle'
+_addon.name = 'MountMuzzle'
 _addon.description = 'Change or remove the default mount music.'
 _addon.author = 'Sjshovan (Apogee) sjshovan@gmail.com'
 _addon.version = '0.9.6'

--- a/addons/MountRoulette/MountRoulette.lua
+++ b/addons/MountRoulette/MountRoulette.lua
@@ -26,7 +26,7 @@ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ]]
 
-_addon.name = 'Mount Roulette'
+_addon.name = 'MountRoulette'
 _addon.author = 'Dean James (Xurion of Bismarck)'
 _addon.version = '3.2.1'
 _addon.commands = {'mountroulette', 'mr'}

--- a/addons/NoCampaignMusic/NoCampaignMusic.lua
+++ b/addons/NoCampaignMusic/NoCampaignMusic.lua
@@ -26,7 +26,7 @@ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ]]
 
-_addon.name = 'No Campaign Music'
+_addon.name = 'NoCampaignMusic'
 _addon.author = 'Dean James (Xurion of Bismarck)'
 _addon.version = '2.0.1'
 _addon.commands = {'nocampaignmusic', 'ncm'}

--- a/addons/autoenterkey/autoenterkey.lua
+++ b/addons/autoenterkey/autoenterkey.lua
@@ -24,7 +24,7 @@
 --(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 --SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-_addon.name = 'Auto Enter Key'
+_addon.name = 'AutoEnterKey'
 _addon.version = '1.0'
 _addon.author = 'Chiaia (Asura)'
 _addon.commands = {'ake',}


### PR DESCRIPTION
There was a Windower version change in late February 2026 that required users to type the content of the "addon name" field of the addon to unload an addon with `lua u AddonName` (rather than typing the file name of the addon.) Doesn't look like it was reverted with that whole update-and-rollback, so **this is a functional change**, but I think new players shouldn't get this experience:
<img width="1020" height="199" alt="Screenshot 2026-04-16 120824" src="https://github.com/user-attachments/assets/ae51121c-cdc8-4732-9a74-2ece948cfd14" />

**Affected addons**: AutoEnterKey, BattleStations, EmpyPopTracker, JobChange, MountMuzzle, NoCampaignMusic, XIVBar
**Changed code:** Literally just the spaces in the "addon name" fields.
...and also Github appears to have strong opinions about the final lines of MountMuzzle and BattleStations, so I assume it's some kind of carriage return thing I don't understand becaues I'm not very bright.