### PR TITLE
add packet 0x008 Previously Visited Zones

### DIFF
--- a/addons/libs/packets/data.lua
+++ b/addons/libs/packets/data.lua
@@ -117,6 +117,7 @@ data.outgoing[0x117] = {name='Unity Ranking Menu',  description='Sent when openi
 data.outgoing[0x118] = {name='Unity Chat Status',   description='Sent when changing unity chat status.'}
 
 -- Server packets (incoming)
+data.incoming[0x008] = {name='Visited Zones',		description='A list of previously visited zones.'}
 data.incoming[0x009] = {name='Standard Message',    description='A standardized message send from FFXI.'}
 data.incoming[0x00A] = {name='Zone In',             description='Info about character and zone around it.'}
 data.incoming[0x00B] = {name='Zone Out',            description='Packet contains IP and port of next zone to connect to.'}

--- a/addons/libs/packets/fields.lua
+++ b/addons/libs/packets/fields.lua
@@ -1270,6 +1270,11 @@ enums['mh door menus'] = {      -- only known use is Mog House exit menu type
     [0x09] = 'Adoulin',         -- no flower girl quest, should always be this value for adoulin mh
 }
 
+-- Visited Zones
+fields.incoming[0x008] = L{
+	{ctype='bit[384]',			label='Zones'},				-- bitfield of previously visited zones
+}
+
 -- Standard Message
 -- Really ancient message packet -- used for log messages like "You throw away X itemNameHere" (Message 180)
 fields.incoming[0x009] = L{


### PR DESCRIPTION
This packet is sent by the server to inform the client of the zones it has previously entered.

bit order is same as zones order in resources `zones.lua`