### PR TITLE
Rename addon to 'xivbar'

### DIFF
--- a/addons/xivbar/xivbar.lua
+++ b/addons/xivbar/xivbar.lua
@@ -27,7 +27,7 @@
 ]]
 
 -- Addon description
-_addon.name = 'XIV Bar'
+_addon.name = 'xivbar'
 _addon.author = 'Edeon'
 _addon.version = '1.0'
 _addon.language = 'english'


### PR DESCRIPTION
Changes the name of the addon to match the folder structure, so that loading and unloading can be done with the same name