### PR TITLE
DressUp: Directory Comparison and Case-Sensitivity Fixes

### DIFF
--- a/addons/DressUp/helper_functions.lua
+++ b/addons/DressUp/helper_functions.lua
@@ -32,7 +32,7 @@ function get_item_id(str,slot)
     else
     
         for k,v in pairs(models[slot]) do
-            if v['enl'] == str or v['name'] == str then
+            if (v['enl'] and v['enl']:lower() == str) or (v['name'] and v['name']:lower() == str) then
                 item_result = k
             end
         end


### PR DESCRIPTION
**Description**: Fixes an issue where profile loading and file comparisons fail on systems/configurations with mismatching folder path casing. By enforcing case insensitivity during the string comparisons against .lua data databases, we ensure robust cross-platform/case-insensitive behavior when the client parses profiles and gear databases.

**Importance**: Prevents silent failures when trying to load gear configurations (such as user profile definitions matching [gear].lua), guaranteeing consistent operation regardless of how directory paths or filenames are capitalized.  
Previous //du self main Apocalypse  would fail due to mismatch and not be recognized.   The 'Apocalypse' in this fix would be lowercased and whatever the user entered would be lowercased regardless of case allowing for dressup to display the weapon.

Without this fix, changing gear in dressup will continue to fail.