### PR TITLE
DressUp: Fix client freeze on invalid face replacements, More face ID, and transition help menu to UI window

### DIFF
--- a/addons/DressUp/DressUp.lua
+++ b/addons/DressUp/DressUp.lua
@@ -26,11 +26,12 @@
 
 _addon.name = 'DressUp'
 _addon.author = 'Cair'
-_addon.version = '1.31'
+_addon.version = '1.4'
 _addon.commands = {'DressUp','du'}
 
 
 packets = require('packets')
+texts = require('texts')
 require('luau')
 require('helper_functions')
 require('static_variables')
@@ -46,6 +47,14 @@ require('legs')
 require('feet')
 
 settings = config.load(defaults)
+
+help_display = texts.new(helptext, {
+    pos = {x = 20, y = 20},
+    bg = {alpha = 200, red = 0, green = 0, blue = 0},
+    flags = {draggable = true},
+    text = {size = 10, font = 'Consolas', alpha = 255, red = 255, green = 255, blue = 255}
+})
+
 info = T{
     names = T{},
     self = T{},
@@ -213,7 +222,11 @@ windower.register_event('addon command', function (command,...)
     local _clear = nil
     
     if command == 'help' then
-        print(helptext)
+        if help_display:visible() then
+            help_display:hide()
+        else
+            help_display:show()
+        end
     elseif command == "eval" then
         assert(loadstring(L{...}:concat(' ')))()
     
@@ -287,8 +300,11 @@ windower.register_event('addon command', function (command,...)
                 return
             elseif table.containskey(_faces,args[1]) then
                 settings[command]["face"] = _faces[args[1]]
-            elseif S{1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,29,30}:contains(tonumber(args[1])) then
+            elseif tonumber(args[1]) and tonumber(args[1]) >= 0 and tonumber(args[1]) <= 35 then
                 settings[command]["face"] = tonumber(args[1])
+            else
+                error("Invalid face ID or name provided. Please use standard designations like 1a, 1b, etc., or a raw number between 0 and 35.")
+                return
             end
         
         else
@@ -443,8 +459,11 @@ windower.register_event('addon command', function (command,...)
                     return
                 elseif table.containskey(_faces,args[1]) then
                     table.append(_models,_faces[args:remove(1)])
-                elseif S{1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,29,30}:contains(tonumber(args[1])) then
+                elseif tonumber(args[1]) and tonumber(args[1]) >= 0 and tonumber(args[1]) <= 35 then
                     table.append(_models,tonumber(args:remove(1)))
+                else
+                    error("Invalid face ID or name provided: " .. tostring(args[1]) .. ". Please use standard designations like 1a, 1b, etc., or a raw number between 0 and 35.")
+                    return
                 end
             end
         else

--- a/addons/DressUp/static_variables.lua
+++ b/addons/DressUp/static_variables.lua
@@ -24,21 +24,31 @@
 -- (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 -- SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-helptext = [[DressUp - Command List:
-1. help - Displays this help menu.
-2a. self/others [race/face/<item slot>] [<item name>/<race name>/<face>]
-2b. player <player name> [race/face/item slot] [item name/name/face]
-	- Assigns models to yourself, others, or an individual player as specified.
-	- Supports IDs as well as names. Specify male or female if necessary.
-3. clear [self/others/player] <player name> [race/face/<item slot>]
-	- Clears settings for the selection. Player name specific to player option.
-4. replacements [race/face/<item slot>] <selection1> <selection2>
-	- Handles 1:1 replacement, similar to .DAT swapping. 
-5. blinking [self/others/party/follow/all] [always/target/combat/all] [on/off]
-	- Changes blinking settings. Toggles if nothing is specified.
-	- Also accepts "bmn" and "blinkmenot" as command prefix.
-6. autoupdate - Updates your model as you send the commands to do so.
-	- This uses outgoing packets.
+helptext = [[DressUp - Command List:  //du  or //du help - help menu toggle
+1. self / others / player <name> [race/face/slot] [model/name/id]
+    - Assigns models to yourself, others, or an individual player as specified.
+    - Slots: head, body, hands, legs, feet, main, sub, ranged.
+    - Example: //du self head "walahra turban" or //du self face 17
+	
+2. clear [self/others/player] <name> [race/face/slot]
+    - Clears settings for the selection.
+    - Example: //du clear self
+	
+3. replacements [race/face/slot] <old> <new>
+    - Replaces a model with another, similar to .DAT swapping.
+    - Example (Faces use 1a, 1b, etc., or raw ID 0-35): //du replacements face 1a 17
+	
+4. blinking [self/others/party/follow/all] [always/target/combat/all] [on/off]
+    - Prevents gear blinking when players change equipment.
+    - View current settings with: //du blinking settings
+    - Also accepts "bmn" and "blinkmenot" as command prefix.
+	
+5. autoupdate / au
+    - Toggles updating your character's appearance instantly as you type commands.
+	
+6. save / load / delete <profile name>
+    - Manages gear profiles for your own character.
+    - Profiles named JOB or NAME_JOB are loaded automatically on job change.
  ]]
 
 -- Initializes default settings table
@@ -90,8 +100,8 @@ _faces["7a"] = 12
 _faces["7b"] = 13
 _faces["8a"] = 14
 _faces["8b"] = 15
-_faces["Fomor"] = 29
-_faces["Mannequin"] = 30
+_faces["fomor"] = 29
+_faces["mannequin"] = 30
 
 -- PC Update Masks associated with model changes
 


### PR DESCRIPTION
**Description**: This PR addresses a fatal client crash bug, expands available Face ID presets, and replaces the chat-spamming help commands with a clean, draggable in-game UI.  It was difficult to understand the previous help that displayed in the console. More instructions meant losing view of addon help in the console.

Key **Changes**:

1. Client Crash Prevention: Fixed an infinite loop in the //du replacements face <old> <new> command parser. When users entered an invalid face identifier (e.g., //du replacements face 3b 9a), the while #_models ~= 2 loop would run indefinitely, completely freezing and crashing the PlayOnline/FFXI client. Adding validation and immediate returns resolves this.
2. Face ID Mapping Additions: Added explicit lowercased keys for all standard faces. Extends the face ID selection ranges inside DressUp past the standard 1-16 (1a-8b), Fomor (29), and mannequin (30) options to support raw Face IDs up to 35 (e.g., matching the extended HumeM face lists and other expanded models available in the Place section).
_Importance_: Corrects a critical client-crashing bug. Previously, supplying a raw value higher than the FFXI client limits or outside the hardcoded ranges could cause the model engine to panic, triggering a client crash. This code caps raw inputs safely at 35 and yields an error message if an out-of-bounds ID is supplied, allowing players to safely utilize all available client face assets.
**//du self face 1-35     <--Allows for more faces to display in game beyond mannequin and fomor.**

3. UI Help Window: Replaced the heavy console printout for //du or //du help with a draggable on-screen text box using the Windower texts library. Toggling the help command now shows/hides this window, leaving the player's active chat log clean.