### PR TITLE
add COR subtype for 0x044 packet

### DIFF
--- a/addons/libs/packets/fields.lua
+++ b/addons/libs/packets/fields.lua
@@ -2377,6 +2377,11 @@ func.incoming[0x044].base = L{
     {ctype='unsigned short',    label='_unknown1'},                             -- 06
 }
 
+-- COR
+func.incoming[0x044][0x11] = L{
+    {ctype='data[4]',           label='Available Rolls'},                       -- 08 bitfield of available Phantom Rolls
+}
+
 -- PUP
 func.incoming[0x044][0x12] = L{
     {ctype='unsigned char',     label='Automaton Head'},                        -- 08   Harlequinn 1, Valoredge 2, Sharpshot 3, Stormwaker 4, Soulsoother 5, Spiritreaver 6


### PR DESCRIPTION
bitfield of available Phantom Rolls, the rest of the packet is all zeroes most of the time
in the same order of CorsairRoll in **job_abilities.lua** resource

"Available Rolls" show for me as `11111111 11111111 00011111 00100101` exactly the mapping of my available rolls, changes to 1 when i learn new one

