### PR TITLE
Update Mote-Include.lua to make player status of 'Event' be handled the same as 'Idle'

### DIFF
--- a/addons/GearSwap/libs/Mote-Include.lua
+++ b/addons/GearSwap/libs/Mote-Include.lua
@@ -460,7 +460,7 @@ function equip_gear_by_status(playerStatus, petStatus)
     
     -- If status not defined, treat as idle.
     -- Be sure to check for positive HP to make sure they're not dead.
-    if (playerStatus == 'Idle' or playerStatus == '') and player.hp > 0 then
+    if (playerStatus == 'Idle' or playerStatus == 'Event' or playerStatus == '') and player.hp > 0 then
         equip(get_idle_set(petStatus))
     elseif playerStatus == 'Engaged' then
         equip(get_melee_set(petStatus))


### PR DESCRIPTION
When players change areas via Home Point crystals, their status is 'Event'. This change is intended to treat that scenario the same as when the player status is 'Idle'.

I have also made a pull request for this same change to the source Mote-libs project: https://github.com/Kinematics/Mote-libs/pull/9. Not totally sure of the best place to handle it.